### PR TITLE
update query keeper methods and complete query keeper tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,6 +101,7 @@ require (
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/gtank/merlin v0.1.1 // indirect
 	github.com/gtank/ristretto255 v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -743,6 +743,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0 h1:1JYBfzqrWPcCclBwxFCPAou9n+q86mfnu7NAeHfte7A=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0/go.mod h1:YDZoGHuwE+ov0c8smSH49WLF3F2LaWnYYuDVd+EWrc0=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/gtank/merlin v0.1.1-0.20191105220539-8318aed1a79f/go.mod h1:T86dnYJhcGOh5BjZFCJWTDeTK7XW8uE+E21Cy/bIQ+s=

--- a/ts-client/madeinblock.slashrefund.slashrefund/module.ts
+++ b/ts-client/madeinblock.slashrefund.slashrefund/module.ts
@@ -7,15 +7,15 @@ import { msgTypes } from './registry';
 import { IgniteClient } from "../client"
 import { MissingWalletError } from "../helpers"
 import { Api } from "./rest";
-import { MsgDeposit } from "./types/slashrefund/tx";
-import { MsgClaim } from "./types/slashrefund/tx";
 import { MsgWithdraw } from "./types/slashrefund/tx";
+import { MsgClaim } from "./types/slashrefund/tx";
+import { MsgDeposit } from "./types/slashrefund/tx";
 
 
-export { MsgDeposit, MsgClaim, MsgWithdraw };
+export { MsgWithdraw, MsgClaim, MsgDeposit };
 
-type sendMsgDepositParams = {
-  value: MsgDeposit,
+type sendMsgWithdrawParams = {
+  value: MsgWithdraw,
   fee?: StdFee,
   memo?: string
 };
@@ -26,23 +26,23 @@ type sendMsgClaimParams = {
   memo?: string
 };
 
-type sendMsgWithdrawParams = {
-  value: MsgWithdraw,
+type sendMsgDepositParams = {
+  value: MsgDeposit,
   fee?: StdFee,
   memo?: string
 };
 
 
-type msgDepositParams = {
-  value: MsgDeposit,
+type msgWithdrawParams = {
+  value: MsgWithdraw,
 };
 
 type msgClaimParams = {
   value: MsgClaim,
 };
 
-type msgWithdrawParams = {
-  value: MsgWithdraw,
+type msgDepositParams = {
+  value: MsgDeposit,
 };
 
 
@@ -63,17 +63,17 @@ export const txClient = ({ signer, prefix, addr }: TxClientOptions = { addr: "ht
 
   return {
 		
-		async sendMsgDeposit({ value, fee, memo }: sendMsgDepositParams): Promise<DeliverTxResponse> {
+		async sendMsgWithdraw({ value, fee, memo }: sendMsgWithdrawParams): Promise<DeliverTxResponse> {
 			if (!signer) {
-					throw new Error('TxClient:sendMsgDeposit: Unable to sign Tx. Signer is not present.')
+					throw new Error('TxClient:sendMsgWithdraw: Unable to sign Tx. Signer is not present.')
 			}
 			try {			
 				const { address } = (await signer.getAccounts())[0]; 
 				const signingClient = await SigningStargateClient.connectWithSigner(addr,signer,{registry, prefix});
-				let msg = this.msgDeposit({ value: MsgDeposit.fromPartial(value) })
+				let msg = this.msgWithdraw({ value: MsgWithdraw.fromPartial(value) })
 				return await signingClient.signAndBroadcast(address, [msg], fee ? fee : defaultFee, memo)
 			} catch (e: any) {
-				throw new Error('TxClient:sendMsgDeposit: Could not broadcast Tx: '+ e.message)
+				throw new Error('TxClient:sendMsgWithdraw: Could not broadcast Tx: '+ e.message)
 			}
 		},
 		
@@ -91,26 +91,26 @@ export const txClient = ({ signer, prefix, addr }: TxClientOptions = { addr: "ht
 			}
 		},
 		
-		async sendMsgWithdraw({ value, fee, memo }: sendMsgWithdrawParams): Promise<DeliverTxResponse> {
+		async sendMsgDeposit({ value, fee, memo }: sendMsgDepositParams): Promise<DeliverTxResponse> {
 			if (!signer) {
-					throw new Error('TxClient:sendMsgWithdraw: Unable to sign Tx. Signer is not present.')
+					throw new Error('TxClient:sendMsgDeposit: Unable to sign Tx. Signer is not present.')
 			}
 			try {			
 				const { address } = (await signer.getAccounts())[0]; 
 				const signingClient = await SigningStargateClient.connectWithSigner(addr,signer,{registry, prefix});
-				let msg = this.msgWithdraw({ value: MsgWithdraw.fromPartial(value) })
+				let msg = this.msgDeposit({ value: MsgDeposit.fromPartial(value) })
 				return await signingClient.signAndBroadcast(address, [msg], fee ? fee : defaultFee, memo)
 			} catch (e: any) {
-				throw new Error('TxClient:sendMsgWithdraw: Could not broadcast Tx: '+ e.message)
+				throw new Error('TxClient:sendMsgDeposit: Could not broadcast Tx: '+ e.message)
 			}
 		},
 		
 		
-		msgDeposit({ value }: msgDepositParams): EncodeObject {
+		msgWithdraw({ value }: msgWithdrawParams): EncodeObject {
 			try {
-				return { typeUrl: "/madeinblock.slashrefund.slashrefund.MsgDeposit", value: MsgDeposit.fromPartial( value ) }  
+				return { typeUrl: "/madeinblock.slashrefund.slashrefund.MsgWithdraw", value: MsgWithdraw.fromPartial( value ) }  
 			} catch (e: any) {
-				throw new Error('TxClient:MsgDeposit: Could not create message: ' + e.message)
+				throw new Error('TxClient:MsgWithdraw: Could not create message: ' + e.message)
 			}
 		},
 		
@@ -122,11 +122,11 @@ export const txClient = ({ signer, prefix, addr }: TxClientOptions = { addr: "ht
 			}
 		},
 		
-		msgWithdraw({ value }: msgWithdrawParams): EncodeObject {
+		msgDeposit({ value }: msgDepositParams): EncodeObject {
 			try {
-				return { typeUrl: "/madeinblock.slashrefund.slashrefund.MsgWithdraw", value: MsgWithdraw.fromPartial( value ) }  
+				return { typeUrl: "/madeinblock.slashrefund.slashrefund.MsgDeposit", value: MsgDeposit.fromPartial( value ) }  
 			} catch (e: any) {
-				throw new Error('TxClient:MsgWithdraw: Could not create message: ' + e.message)
+				throw new Error('TxClient:MsgDeposit: Could not create message: ' + e.message)
 			}
 		},
 		

--- a/ts-client/madeinblock.slashrefund.slashrefund/registry.ts
+++ b/ts-client/madeinblock.slashrefund.slashrefund/registry.ts
@@ -1,12 +1,12 @@
 import { GeneratedType } from "@cosmjs/proto-signing";
-import { MsgDeposit } from "./types/slashrefund/tx";
-import { MsgClaim } from "./types/slashrefund/tx";
 import { MsgWithdraw } from "./types/slashrefund/tx";
+import { MsgClaim } from "./types/slashrefund/tx";
+import { MsgDeposit } from "./types/slashrefund/tx";
 
 const msgTypes: Array<[string, GeneratedType]>  = [
-    ["/madeinblock.slashrefund.slashrefund.MsgDeposit", MsgDeposit],
-    ["/madeinblock.slashrefund.slashrefund.MsgClaim", MsgClaim],
     ["/madeinblock.slashrefund.slashrefund.MsgWithdraw", MsgWithdraw],
+    ["/madeinblock.slashrefund.slashrefund.MsgClaim", MsgClaim],
+    ["/madeinblock.slashrefund.slashrefund.MsgDeposit", MsgDeposit],
     
 ];
 

--- a/ts-client/madeinblock.slashrefund.slashrefund/types/slashrefund/tx.ts
+++ b/ts-client/madeinblock.slashrefund.slashrefund/types/slashrefund/tx.ts
@@ -35,7 +35,6 @@ export interface MsgClaim {
    */
   delegatorAddress: string;
   validatorAddress: string;
-  amount: Coin | undefined;
 }
 
 export interface MsgClaimResponse {
@@ -266,7 +265,7 @@ export const MsgWithdrawResponse = {
 };
 
 function createBaseMsgClaim(): MsgClaim {
-  return { delegatorAddress: "", validatorAddress: "", amount: undefined };
+  return { delegatorAddress: "", validatorAddress: "" };
 }
 
 export const MsgClaim = {
@@ -276,9 +275,6 @@ export const MsgClaim = {
     }
     if (message.validatorAddress !== "") {
       writer.uint32(18).string(message.validatorAddress);
-    }
-    if (message.amount !== undefined) {
-      Coin.encode(message.amount, writer.uint32(26).fork()).ldelim();
     }
     return writer;
   },
@@ -296,9 +292,6 @@ export const MsgClaim = {
         case 2:
           message.validatorAddress = reader.string();
           break;
-        case 3:
-          message.amount = Coin.decode(reader, reader.uint32());
-          break;
         default:
           reader.skipType(tag & 7);
           break;
@@ -311,7 +304,6 @@ export const MsgClaim = {
     return {
       delegatorAddress: isSet(object.delegatorAddress) ? String(object.delegatorAddress) : "",
       validatorAddress: isSet(object.validatorAddress) ? String(object.validatorAddress) : "",
-      amount: isSet(object.amount) ? Coin.fromJSON(object.amount) : undefined,
     };
   },
 
@@ -319,7 +311,6 @@ export const MsgClaim = {
     const obj: any = {};
     message.delegatorAddress !== undefined && (obj.delegatorAddress = message.delegatorAddress);
     message.validatorAddress !== undefined && (obj.validatorAddress = message.validatorAddress);
-    message.amount !== undefined && (obj.amount = message.amount ? Coin.toJSON(message.amount) : undefined);
     return obj;
   },
 
@@ -327,9 +318,6 @@ export const MsgClaim = {
     const message = createBaseMsgClaim();
     message.delegatorAddress = object.delegatorAddress ?? "";
     message.validatorAddress = object.validatorAddress ?? "";
-    message.amount = (object.amount !== undefined && object.amount !== null)
-      ? Coin.fromPartial(object.amount)
-      : undefined;
     return message;
   },
 };

--- a/vue/src/store/generated/madeinblock.slashrefund.slashrefund/index.ts
+++ b/vue/src/store/generated/madeinblock.slashrefund.slashrefund/index.ts
@@ -456,19 +456,6 @@ export default {
 		},
 		
 		
-		async sendMsgDeposit({ rootGetters }, { value, fee = [], memo = '' }) {
-			try {
-				const client=await initClient(rootGetters)
-				const result = await client.MadeinblockSlashrefundSlashrefund.tx.sendMsgDeposit({ value, fee: {amount: fee, gas: "200000"}, memo })
-				return result
-			} catch (e) {
-				if (e == MissingWalletError) {
-					throw new Error('TxClient:MsgDeposit:Init Could not initialize signing client. Wallet is required.')
-				}else{
-					throw new Error('TxClient:MsgDeposit:Send Could not broadcast Tx: '+ e.message)
-				}
-			}
-		},
 		async sendMsgWithdraw({ rootGetters }, { value, fee = [], memo = '' }) {
 			try {
 				const client=await initClient(rootGetters)
@@ -495,20 +482,20 @@ export default {
 				}
 			}
 		},
-		
-		async MsgDeposit({ rootGetters }, { value }) {
+		async sendMsgDeposit({ rootGetters }, { value, fee = [], memo = '' }) {
 			try {
-				const client=initClient(rootGetters)
-				const msg = await client.MadeinblockSlashrefundSlashrefund.tx.msgDeposit({value})
-				return msg
+				const client=await initClient(rootGetters)
+				const result = await client.MadeinblockSlashrefundSlashrefund.tx.sendMsgDeposit({ value, fee: {amount: fee, gas: "200000"}, memo })
+				return result
 			} catch (e) {
 				if (e == MissingWalletError) {
 					throw new Error('TxClient:MsgDeposit:Init Could not initialize signing client. Wallet is required.')
-				} else{
-					throw new Error('TxClient:MsgDeposit:Create Could not create message: ' + e.message)
+				}else{
+					throw new Error('TxClient:MsgDeposit:Send Could not broadcast Tx: '+ e.message)
 				}
 			}
 		},
+		
 		async MsgWithdraw({ rootGetters }, { value }) {
 			try {
 				const client=initClient(rootGetters)
@@ -532,6 +519,19 @@ export default {
 					throw new Error('TxClient:MsgClaim:Init Could not initialize signing client. Wallet is required.')
 				} else{
 					throw new Error('TxClient:MsgClaim:Create Could not create message: ' + e.message)
+				}
+			}
+		},
+		async MsgDeposit({ rootGetters }, { value }) {
+			try {
+				const client=initClient(rootGetters)
+				const msg = await client.MadeinblockSlashrefundSlashrefund.tx.msgDeposit({value})
+				return msg
+			} catch (e) {
+				if (e == MissingWalletError) {
+					throw new Error('TxClient:MsgDeposit:Init Could not initialize signing client. Wallet is required.')
+				} else{
+					throw new Error('TxClient:MsgDeposit:Create Could not create message: ' + e.message)
 				}
 			}
 		},

--- a/x/slashrefund/keeper/grpc_query_deposit.go
+++ b/x/slashrefund/keeper/grpc_query_deposit.go
@@ -41,7 +41,7 @@ func (k Querier) DepositAll(c context.Context, req *types.QueryAllDepositRequest
 
 func (k Querier) Deposit(c context.Context, req *types.QueryGetDepositRequest) (*types.QueryGetDepositResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 
 	if req.DepositorAddress == "" {

--- a/x/slashrefund/keeper/grpc_query_deposit_pool.go
+++ b/x/slashrefund/keeper/grpc_query_deposit_pool.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func (k Keeper) DepositPoolAll(c context.Context, req *types.QueryAllDepositPoolRequest) (*types.QueryAllDepositPoolResponse, error) {
+func (k Querier) DepositPoolAll(c context.Context, req *types.QueryAllDepositPoolRequest) (*types.QueryAllDepositPoolResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
@@ -39,9 +39,9 @@ func (k Keeper) DepositPoolAll(c context.Context, req *types.QueryAllDepositPool
 	return &types.QueryAllDepositPoolResponse{DepositPool: depositPools, Pagination: pageRes}, nil
 }
 
-func (k Keeper) DepositPool(c context.Context, req *types.QueryGetDepositPoolRequest) (*types.QueryGetDepositPoolResponse, error) {
+func (k Querier) DepositPool(c context.Context, req *types.QueryGetDepositPoolRequest) (*types.QueryGetDepositPoolResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 	valOperAddr, err := sdk.ValAddressFromBech32(req.OperatorAddress)
 	if err != nil {

--- a/x/slashrefund/keeper/grpc_query_deposit_pool_test.go
+++ b/x/slashrefund/keeper/grpc_query_deposit_pool_test.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/made-in-block/slash-refund/testutil/nullify"
-	//"github.com/made-in-block/slash-refund/x/slashrefund/testslashrefund"
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
 )
 
@@ -78,8 +77,8 @@ func TestDepositPoolQuerySingle(t *testing.T) {
 func TestDepositPoolQueryPaginated(t *testing.T) {
 	s := SetupTestSuite(t, 100)
 	srApp, ctx, querier := s.srApp, s.ctx, s.querier
-
 	wctx := sdk.WrapSDKContext(ctx)
+
 	depPools := createNDepositPool(&srApp.SlashrefundKeeper, ctx, 5)
 
 	request := func(next []byte, offset, limit uint64, total bool) *types.QueryAllDepositPoolRequest {

--- a/x/slashrefund/keeper/grpc_query_deposit_pool_test.go
+++ b/x/slashrefund/keeper/grpc_query_deposit_pool_test.go
@@ -1,7 +1,6 @@
 package keeper_test
 
 import (
-	"strconv"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -15,13 +14,16 @@ import (
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
 )
 
-// Prevent strconv unused error
-var _ = strconv.IntSize
-
 func TestDepositPoolQuerySingle(t *testing.T) {
-	keeper, ctx := testslashrefund.NewTestKeeper(t)
+	k, ctx := testslashrefund.NewTestKeeper(t)
 	wctx := sdk.WrapSDKContext(ctx)
-	msgs := createNDepositPool(keeper, ctx, 2)
+	depPools := createNDepositPool(k, ctx, 3)
+
+	// remove last deposit pool to test "KeyNotFound"
+	valAddr, err := sdk.ValAddressFromBech32(depPools[2].OperatorAddress)
+	require.NoError(t, err)
+	k.RemoveDepositPool(ctx, valAddr)
+
 	for _, tc := range []struct {
 		desc     string
 		request  *types.QueryGetDepositPoolRequest
@@ -31,23 +33,23 @@ func TestDepositPoolQuerySingle(t *testing.T) {
 		{
 			desc: "First",
 			request: &types.QueryGetDepositPoolRequest{
-				OperatorAddress: msgs[0].OperatorAddress,
+				OperatorAddress: depPools[0].OperatorAddress,
 			},
-			response: &types.QueryGetDepositPoolResponse{DepositPool: msgs[0]},
+			response: &types.QueryGetDepositPoolResponse{DepositPool: depPools[0]},
 		},
 		{
 			desc: "Second",
 			request: &types.QueryGetDepositPoolRequest{
-				OperatorAddress: msgs[1].OperatorAddress,
+				OperatorAddress: depPools[1].OperatorAddress,
 			},
-			response: &types.QueryGetDepositPoolResponse{DepositPool: msgs[1]},
+			response: &types.QueryGetDepositPoolResponse{DepositPool: depPools[1]},
 		},
 		{
 			desc: "KeyNotFound",
 			request: &types.QueryGetDepositPoolRequest{
-				OperatorAddress: strconv.Itoa(100000),
+				OperatorAddress: depPools[2].OperatorAddress,
 			},
-			err: status.Error(codes.NotFound, "not found"),
+			err: status.Errorf(codes.NotFound, "deposit pool not found for operator %s", depPools[2].OperatorAddress),
 		},
 		{
 			desc: "InvalidRequest",
@@ -55,7 +57,7 @@ func TestDepositPoolQuerySingle(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			response, err := keeper.DepositPool(wctx, tc.request)
+			response, err := k.DepositPool(wctx, tc.request)
 			if tc.err != nil {
 				require.ErrorIs(t, err, tc.err)
 			} else {
@@ -70,9 +72,9 @@ func TestDepositPoolQuerySingle(t *testing.T) {
 }
 
 func TestDepositPoolQueryPaginated(t *testing.T) {
-	keeper, ctx := testslashrefund.NewTestKeeper(t)
+	k, ctx := testslashrefund.NewTestKeeper(t)
 	wctx := sdk.WrapSDKContext(ctx)
-	msgs := createNDepositPool(keeper, ctx, 5)
+	depPools := createNDepositPool(k, ctx, 5)
 
 	request := func(next []byte, offset, limit uint64, total bool) *types.QueryAllDepositPoolRequest {
 		return &types.QueryAllDepositPoolRequest{
@@ -86,12 +88,12 @@ func TestDepositPoolQueryPaginated(t *testing.T) {
 	}
 	t.Run("ByOffset", func(t *testing.T) {
 		step := 2
-		for i := 0; i < len(msgs); i += step {
-			resp, err := keeper.DepositPoolAll(wctx, request(nil, uint64(i), uint64(step), false))
+		for i := 0; i < len(depPools); i += step {
+			resp, err := k.DepositPoolAll(wctx, request(nil, uint64(i), uint64(step), false))
 			require.NoError(t, err)
 			require.LessOrEqual(t, len(resp.DepositPool), step)
 			require.Subset(t,
-				nullify.Fill(msgs),
+				nullify.Fill(depPools),
 				nullify.Fill(resp.DepositPool),
 			)
 		}
@@ -99,28 +101,28 @@ func TestDepositPoolQueryPaginated(t *testing.T) {
 	t.Run("ByKey", func(t *testing.T) {
 		step := 2
 		var next []byte
-		for i := 0; i < len(msgs); i += step {
-			resp, err := keeper.DepositPoolAll(wctx, request(next, 0, uint64(step), false))
+		for i := 0; i < len(depPools); i += step {
+			resp, err := k.DepositPoolAll(wctx, request(next, 0, uint64(step), false))
 			require.NoError(t, err)
 			require.LessOrEqual(t, len(resp.DepositPool), step)
 			require.Subset(t,
-				nullify.Fill(msgs),
+				nullify.Fill(depPools),
 				nullify.Fill(resp.DepositPool),
 			)
 			next = resp.Pagination.NextKey
 		}
 	})
 	t.Run("Total", func(t *testing.T) {
-		resp, err := keeper.DepositPoolAll(wctx, request(nil, 0, 0, true))
+		resp, err := k.DepositPoolAll(wctx, request(nil, 0, 0, true))
 		require.NoError(t, err)
-		require.Equal(t, len(msgs), int(resp.Pagination.Total))
+		require.Equal(t, len(depPools), int(resp.Pagination.Total))
 		require.ElementsMatch(t,
-			nullify.Fill(msgs),
+			nullify.Fill(depPools),
 			nullify.Fill(resp.DepositPool),
 		)
 	})
-	t.Run("InvalidRequest", func(t *testing.T) {
-		_, err := keeper.DepositPoolAll(wctx, nil)
+	t.Run("Invalid Request", func(t *testing.T) {
+		_, err := k.DepositPoolAll(wctx, nil)
 		require.ErrorIs(t, err, status.Error(codes.InvalidArgument, "invalid request"))
 	})
 }

--- a/x/slashrefund/keeper/grpc_query_deposit_test.go
+++ b/x/slashrefund/keeper/grpc_query_deposit_test.go
@@ -1,135 +1,140 @@
 package keeper_test
 
-// import (
-// 	"strconv"
-// 	"testing"
+import (
+	"testing"
 
-// 	sdk "github.com/cosmos/cosmos-sdk/types"
-// 	"github.com/cosmos/cosmos-sdk/types/query"
-// 	"github.com/stretchr/testify/require"
-// 	"google.golang.org/grpc/codes"
-// 	"google.golang.org/grpc/status"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/made-in-block/slash-refund/testutil/nullify"
+	"github.com/made-in-block/slash-refund/x/slashrefund/keeper"
+	"github.com/made-in-block/slash-refund/x/slashrefund/testslashrefund"
+	"github.com/made-in-block/slash-refund/x/slashrefund/types"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
 
-// 	"github.com/made-in-block/slash-refund/x/slashrefund/testslashrefund"
-// 	"github.com/made-in-block/slash-refund/testutil/nullify"
-// 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
-// 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-// )
+func TestDepositQuerySingle(t *testing.T) {
+	s := bootstrapRefundTest(t, 100)
+	srApp, ctx, testAddrs, valAddrs := s.srApp, s.ctx, s.testAddrs, s.valAddrs
 
-// // Prevent strconv unused error
-// var _ = strconv.IntSize
+	k := srApp.SlashrefundKeeper
+	querier := keeper.Querier{Keeper: k}
+	wctx := sdk.WrapSDKContext(ctx)
 
-// func TestDepositQuerySingle(t *testing.T) {
-// 	keeper, ctx := testslashrefund.NewTestKeeper(t)
-// 	wctx := sdk.WrapSDKContext(ctx)
-// 	_ = wctx
-// 	msgs := createNDeposit(keeper, ctx, 2)
-// 	for _, tc := range []struct {
-// 		desc     string
-// 		request  *types.QueryGetDepositRequest
-// 		response *types.QueryGetDepositResponse
-// 		err      error
-// 	}{
-// 		{
-// 			desc: "First",
-// 			request: &types.QueryGetDepositRequest{
-// 				DepositorAddress: msgs[0].DepositorAddress,
-// 				ValidatorAddress: msgs[0].ValidatorAddress,
-// 			},
-// 			response: &types.QueryGetDepositResponse{Deposit: msgs[0]},
-// 		},
-// 		{
-// 			desc: "Second",
-// 			request: &types.QueryGetDepositRequest{
-// 				DepositorAddress: msgs[1].DepositorAddress,
-// 				ValidatorAddress: msgs[1].ValidatorAddress,
-// 			},
-// 			response: &types.QueryGetDepositResponse{Deposit: msgs[1]},
-// 		},
-// 		{
-// 			desc: "KeyNotFound",
-// 			request: &types.QueryGetDepositRequest{
-// 				DepositorAddress: strconv.Itoa(100000),
-// 				ValidatorAddress: strconv.Itoa(100000),
-// 			},
-// 			err: status.Error(codes.NotFound, "not found"),
-// 		},
-// 		{
-// 			desc: "InvalidRequest",
-// 			err:  status.Error(codes.InvalidArgument, "invalid request"),
-// 		},
-// 	} {
-// 		t.Run(tc.desc, func(t *testing.T) {
-// 			valAddr, _ := sdk.ValAddressFromBech32(tc.request.ValidatorAddress)
-// 			depAddr, _ := sdk.AccAddressFromBech32(tc.request.DepositorAddress)
-// 			validator, _ := types.StakingKeeper.GetValidator(ctx, valAddr)
-// 			depCoin := sdk.NewCoin("stake",sdk.NewInt(10))
-// 			response, err := keeper.Deposit(ctx, depAddr, depCoin, validator)
-// 			if tc.err != nil {
-// 				require.ErrorIs(t, err, tc.err)
-// 			} else {
-// 				require.NoError(t, err)
-// 				require.Equal(t,
-// 					nullify.Fill(tc.response),
-// 					nullify.Fill(response),
-// 				)
-// 			}
-// 		})
-// 	}
-// }
+	dep1 := types.NewDeposit(testAddrs[0], valAddrs[0], sdk.NewDec(100))
+	k.SetDeposit(ctx, dep1)
 
-// func TestDepositQueryPaginated(t *testing.T) {
-// 	keeper, ctx := testslashrefund.NewTestKeeper(t)
-// 	wctx := sdk.WrapSDKContext(ctx)
-// 	msgs := createNDeposit(keeper, ctx, 5)
+	dep2 := types.NewDeposit(testAddrs[1], valAddrs[0], sdk.NewDec(100))
+	k.SetDeposit(ctx, dep2)
 
-// 	request := func(next []byte, offset, limit uint64, total bool) *types.QueryAllDepositRequest {
-// 		return &types.QueryAllDepositRequest{
-// 			Pagination: &query.PageRequest{
-// 				Key:        next,
-// 				Offset:     offset,
-// 				Limit:      limit,
-// 				CountTotal: total,
-// 			},
-// 		}
-// 	}
-// 	t.Run("ByOffset", func(t *testing.T) {
-// 		step := 2
-// 		for i := 0; i < len(msgs); i += step {
-// 			resp, err := keeper.DepositAll(wctx, request(nil, uint64(i), uint64(step), false))
-// 			require.NoError(t, err)
-// 			require.LessOrEqual(t, len(resp.Deposit), step)
-// 			require.Subset(t,
-// 				nullify.Fill(msgs),
-// 				nullify.Fill(resp.Deposit),
-// 			)
-// 		}
-// 	})
-// 	t.Run("ByKey", func(t *testing.T) {
-// 		step := 2
-// 		var next []byte
-// 		for i := 0; i < len(msgs); i += step {
-// 			resp, err := keeper.DepositAll(wctx, request(next, 0, uint64(step), false))
-// 			require.NoError(t, err)
-// 			require.LessOrEqual(t, len(resp.Deposit), step)
-// 			require.Subset(t,
-// 				nullify.Fill(msgs),
-// 				nullify.Fill(resp.Deposit),
-// 			)
-// 			next = resp.Pagination.NextKey
-// 		}
-// 	})
-// 	t.Run("Total", func(t *testing.T) {
-// 		resp, err := keeper.DepositAll(wctx, request(nil, 0, 0, true))
-// 		require.NoError(t, err)
-// 		require.Equal(t, len(msgs), int(resp.Pagination.Total))
-// 		require.ElementsMatch(t,
-// 			nullify.Fill(msgs),
-// 			nullify.Fill(resp.Deposit),
-// 		)
-// 	})
-// 	t.Run("InvalidRequest", func(t *testing.T) {
-// 		_, err := keeper.DepositAll(wctx, nil)
-// 		require.ErrorIs(t, err, status.Error(codes.InvalidArgument, "invalid request"))
-// 	})
-// }
+	for _, tc := range []struct {
+		desc     string
+		request  *types.QueryGetDepositRequest
+		response *types.QueryGetDepositResponse
+		err      error
+	}{
+		{
+			desc: "First",
+			request: &types.QueryGetDepositRequest{
+				DepositorAddress: dep1.DepositorAddress,
+				ValidatorAddress: dep1.ValidatorAddress,
+			},
+			response: &types.QueryGetDepositResponse{Deposit: dep1},
+		},
+		{
+			desc: "Second",
+			request: &types.QueryGetDepositRequest{
+				DepositorAddress: dep2.DepositorAddress,
+				ValidatorAddress: dep2.ValidatorAddress,
+			},
+			response: &types.QueryGetDepositResponse{Deposit: dep2},
+		},
+		{
+			desc: "KeyNotFound",
+			request: &types.QueryGetDepositRequest{
+				DepositorAddress: testAddrs[1].String(),
+				ValidatorAddress: valAddrs[1].String(),
+			},
+			err: status.Errorf(codes.NotFound, "deposit with depositor %s not found for validator %s", testAddrs[1].String(), valAddrs[1].String()),
+		},
+		{
+			desc: "InvalidRequest",
+			err:  status.Error(codes.InvalidArgument, "invalid request"),
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+
+			response, err := querier.Deposit(wctx, tc.request)
+
+			if tc.err != nil {
+				require.ErrorIs(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t,
+					nullify.Fill(tc.response),
+					nullify.Fill(response),
+				)
+			}
+		})
+	}
+}
+func TestDepositQueryPaginated(t *testing.T) {
+	k, ctx := testslashrefund.NewTestKeeper(t)
+
+	querier := keeper.Querier{Keeper: *k}
+	wctx := sdk.WrapSDKContext(ctx)
+
+	deposits := createNDeposit(k, ctx, 5)
+
+	request := func(next []byte, offset, limit uint64, total bool) *types.QueryAllDepositRequest {
+		return &types.QueryAllDepositRequest{
+			Pagination: &query.PageRequest{
+				Key:        next,
+				Offset:     offset,
+				Limit:      limit,
+				CountTotal: total,
+			},
+		}
+	}
+
+	t.Run("ByOffset", func(t *testing.T) {
+		step := 2
+		for i := 0; i < len(deposits); i += step {
+			resp, err := querier.DepositAll(wctx, request(nil, uint64(i), uint64(step), false))
+			require.NoError(t, err)
+			require.LessOrEqual(t, len(resp.Deposit), step)
+			require.Subset(t,
+				nullify.Fill(deposits),
+				nullify.Fill(resp.Deposit),
+			)
+		}
+	})
+	t.Run("ByKey", func(t *testing.T) {
+		step := 2
+		var next []byte
+		for i := 0; i < len(deposits); i += step {
+			resp, err := querier.DepositAll(wctx, request(next, 0, uint64(step), false))
+			require.NoError(t, err)
+			require.LessOrEqual(t, len(resp.Deposit), step)
+			require.Subset(t,
+				nullify.Fill(deposits),
+				nullify.Fill(resp.Deposit),
+			)
+			next = resp.Pagination.NextKey
+		}
+	})
+	t.Run("Total", func(t *testing.T) {
+		resp, err := querier.DepositAll(wctx, request(nil, 0, 0, true))
+		require.NoError(t, err)
+		require.Equal(t, len(deposits), int(resp.Pagination.Total))
+		require.ElementsMatch(t,
+			nullify.Fill(deposits),
+			nullify.Fill(resp.Deposit),
+		)
+	})
+	t.Run("InvalidRequest", func(t *testing.T) {
+		_, err := querier.DepositAll(wctx, nil)
+		require.ErrorIs(t, err, status.Error(codes.InvalidArgument, "invalid request"))
+	})
+}

--- a/x/slashrefund/keeper/grpc_query_deposit_test.go
+++ b/x/slashrefund/keeper/grpc_query_deposit_test.go
@@ -77,7 +77,6 @@ func TestDepositQuerySingle(t *testing.T) {
 func TestDepositQueryPaginated(t *testing.T) {
 	s := SetupTestSuite(t, 100)
 	srApp, ctx, querier := s.srApp, s.ctx, s.querier
-
 	wctx := sdk.WrapSDKContext(ctx)
 
 	deposits := createNDeposit(&srApp.SlashrefundKeeper, ctx, 5)

--- a/x/slashrefund/keeper/grpc_query_params.go
+++ b/x/slashrefund/keeper/grpc_query_params.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func (k Keeper) Params(c context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
+func (k Querier) Params(c context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}

--- a/x/slashrefund/keeper/grpc_query_params_test.go
+++ b/x/slashrefund/keeper/grpc_query_params_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestParamsQuery(t *testing.T) {
-
 	s := SetupTestSuite(t, 100)
 	srApp, ctx, querier := s.srApp, s.ctx, s.querier
 	wctx := sdk.WrapSDKContext(ctx)

--- a/x/slashrefund/keeper/grpc_query_params_test.go
+++ b/x/slashrefund/keeper/grpc_query_params_test.go
@@ -4,18 +4,20 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/made-in-block/slash-refund/x/slashrefund/testslashrefund"
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParamsQuery(t *testing.T) {
-	keeper, ctx := testslashrefund.NewTestKeeper(t)
-	wctx := sdk.WrapSDKContext(ctx)
-	params := types.DefaultParams()
-	keeper.SetParams(ctx, params)
 
-	response, err := keeper.Params(wctx, &types.QueryParamsRequest{})
+	s := SetupTestSuite(t, 100)
+	srApp, ctx, querier := s.srApp, s.ctx, s.querier
+	wctx := sdk.WrapSDKContext(ctx)
+
+	params := types.DefaultParams()
+	srApp.SlashrefundKeeper.SetParams(ctx, params)
+
+	response, err := querier.Params(wctx, &types.QueryParamsRequest{})
 	require.NoError(t, err)
 	require.Equal(t, &types.QueryParamsResponse{Params: params}, response)
 }

--- a/x/slashrefund/keeper/grpc_query_refund.go
+++ b/x/slashrefund/keeper/grpc_query_refund.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func (k Keeper) RefundAll(c context.Context, req *types.QueryAllRefundRequest) (*types.QueryAllRefundResponse, error) {
+func (k Querier) RefundAll(c context.Context, req *types.QueryAllRefundRequest) (*types.QueryAllRefundResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
@@ -39,9 +39,9 @@ func (k Keeper) RefundAll(c context.Context, req *types.QueryAllRefundRequest) (
 	return &types.QueryAllRefundResponse{Refund: refunds, Pagination: pageRes}, nil
 }
 
-func (k Keeper) Refund(c context.Context, req *types.QueryGetRefundRequest) (*types.QueryGetRefundResponse, error) {
+func (k Querier) Refund(c context.Context, req *types.QueryGetRefundRequest) (*types.QueryGetRefundResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 
 	if req.Delegator == "" {

--- a/x/slashrefund/keeper/grpc_query_refund_pool.go
+++ b/x/slashrefund/keeper/grpc_query_refund_pool.go
@@ -52,7 +52,7 @@ func (k Querier) RefundPool(c context.Context, req *types.QueryGetRefundPoolRequ
 
 	refPool, found := k.GetRefundPool(ctx, valAddr)
 	if !found {
-		return nil, status.Error(codes.NotFound, "refund pool not found")
+		return nil, status.Error(codes.NotFound, "not found")
 	}
 
 	return &types.QueryGetRefundPoolResponse{RefundPool: refPool}, nil

--- a/x/slashrefund/keeper/grpc_query_refund_pool.go
+++ b/x/slashrefund/keeper/grpc_query_refund_pool.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func (k Keeper) RefundPoolAll(c context.Context, req *types.QueryAllRefundPoolRequest) (*types.QueryAllRefundPoolResponse, error) {
+func (k Querier) RefundPoolAll(c context.Context, req *types.QueryAllRefundPoolRequest) (*types.QueryAllRefundPoolResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
@@ -39,7 +39,7 @@ func (k Keeper) RefundPoolAll(c context.Context, req *types.QueryAllRefundPoolRe
 	return &types.QueryAllRefundPoolResponse{RefundPool: refundPools, Pagination: pageRes}, nil
 }
 
-func (k Keeper) RefundPool(c context.Context, req *types.QueryGetRefundPoolRequest) (*types.QueryGetRefundPoolResponse, error) {
+func (k Querier) RefundPool(c context.Context, req *types.QueryGetRefundPoolRequest) (*types.QueryGetRefundPoolResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}

--- a/x/slashrefund/keeper/grpc_query_refund_test.go
+++ b/x/slashrefund/keeper/grpc_query_refund_test.go
@@ -16,7 +16,6 @@ import (
 func TestRefundQuerySingle(t *testing.T) {
 	s := SetupTestSuite(t, 100)
 	srApp, ctx, testAddrs, valAddrs, querier := s.srApp, s.ctx, s.testAddrs, s.valAddrs, s.querier
-
 	wctx := sdk.WrapSDKContext(ctx)
 
 	ref1 := types.NewRefund(testAddrs[0], valAddrs[0], sdk.NewDec(100))

--- a/x/slashrefund/keeper/grpc_query_refund_test.go
+++ b/x/slashrefund/keeper/grpc_query_refund_test.go
@@ -1,7 +1,6 @@
 package keeper_test
 
 import (
-	"strconv"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -11,17 +10,21 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/made-in-block/slash-refund/testutil/nullify"
-	"github.com/made-in-block/slash-refund/x/slashrefund/testslashrefund"
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
 )
 
-// Prevent strconv unused error
-var _ = strconv.IntSize
-
 func TestRefundQuerySingle(t *testing.T) {
-	keeper, ctx := testslashrefund.NewTestKeeper(t)
+	s := SetupTestSuite(t, 100)
+	srApp, ctx, testAddrs, valAddrs, querier := s.srApp, s.ctx, s.testAddrs, s.valAddrs, s.querier
+
 	wctx := sdk.WrapSDKContext(ctx)
-	msgs := createNRefund(keeper, ctx, 2)
+
+	ref1 := types.NewRefund(testAddrs[0], valAddrs[0], sdk.NewDec(100))
+	srApp.SlashrefundKeeper.SetRefund(ctx, ref1)
+
+	ref2 := types.NewRefund(testAddrs[1], valAddrs[0], sdk.NewDec(100))
+	srApp.SlashrefundKeeper.SetRefund(ctx, ref2)
+
 	for _, tc := range []struct {
 		desc     string
 		request  *types.QueryGetRefundRequest
@@ -31,24 +34,24 @@ func TestRefundQuerySingle(t *testing.T) {
 		{
 			desc: "First",
 			request: &types.QueryGetRefundRequest{
-				Delegator: msgs[0].DelegatorAddress,
-				Validator: msgs[0].ValidatorAddress,
+				Delegator: testAddrs[0].String(),
+				Validator: valAddrs[0].String(),
 			},
-			response: &types.QueryGetRefundResponse{Refund: msgs[0]},
+			response: &types.QueryGetRefundResponse{Refund: ref1},
 		},
 		{
 			desc: "Second",
 			request: &types.QueryGetRefundRequest{
-				Delegator: msgs[1].DelegatorAddress,
-				Validator: msgs[1].ValidatorAddress,
+				Delegator: testAddrs[1].String(),
+				Validator: valAddrs[0].String(),
 			},
-			response: &types.QueryGetRefundResponse{Refund: msgs[1]},
+			response: &types.QueryGetRefundResponse{Refund: ref2},
 		},
 		{
 			desc: "KeyNotFound",
 			request: &types.QueryGetRefundRequest{
-				Delegator: strconv.Itoa(100000),
-				Validator: strconv.Itoa(100000),
+				Delegator: testAddrs[1].String(),
+				Validator: valAddrs[1].String(),
 			},
 			err: status.Error(codes.NotFound, "not found"),
 		},
@@ -58,7 +61,7 @@ func TestRefundQuerySingle(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			response, err := keeper.Refund(wctx, tc.request)
+			response, err := querier.Refund(wctx, tc.request)
 			if tc.err != nil {
 				require.ErrorIs(t, err, tc.err)
 			} else {
@@ -73,9 +76,11 @@ func TestRefundQuerySingle(t *testing.T) {
 }
 
 func TestRefundQueryPaginated(t *testing.T) {
-	keeper, ctx := testslashrefund.NewTestKeeper(t)
+	s := SetupTestSuite(t, 100)
+	srApp, ctx, querier := s.srApp, s.ctx, s.querier
 	wctx := sdk.WrapSDKContext(ctx)
-	msgs := createNRefund(keeper, ctx, 5)
+
+	refunds := createNRefund(&srApp.SlashrefundKeeper, ctx, 5)
 
 	request := func(next []byte, offset, limit uint64, total bool) *types.QueryAllRefundRequest {
 		return &types.QueryAllRefundRequest{
@@ -89,12 +94,12 @@ func TestRefundQueryPaginated(t *testing.T) {
 	}
 	t.Run("ByOffset", func(t *testing.T) {
 		step := 2
-		for i := 0; i < len(msgs); i += step {
-			resp, err := keeper.RefundAll(wctx, request(nil, uint64(i), uint64(step), false))
+		for i := 0; i < len(refunds); i += step {
+			resp, err := querier.RefundAll(wctx, request(nil, uint64(i), uint64(step), false))
 			require.NoError(t, err)
 			require.LessOrEqual(t, len(resp.Refund), step)
 			require.Subset(t,
-				nullify.Fill(msgs),
+				nullify.Fill(refunds),
 				nullify.Fill(resp.Refund),
 			)
 		}
@@ -102,28 +107,28 @@ func TestRefundQueryPaginated(t *testing.T) {
 	t.Run("ByKey", func(t *testing.T) {
 		step := 2
 		var next []byte
-		for i := 0; i < len(msgs); i += step {
-			resp, err := keeper.RefundAll(wctx, request(next, 0, uint64(step), false))
+		for i := 0; i < len(refunds); i += step {
+			resp, err := querier.RefundAll(wctx, request(next, 0, uint64(step), false))
 			require.NoError(t, err)
 			require.LessOrEqual(t, len(resp.Refund), step)
 			require.Subset(t,
-				nullify.Fill(msgs),
+				nullify.Fill(refunds),
 				nullify.Fill(resp.Refund),
 			)
 			next = resp.Pagination.NextKey
 		}
 	})
 	t.Run("Total", func(t *testing.T) {
-		resp, err := keeper.RefundAll(wctx, request(nil, 0, 0, true))
+		resp, err := querier.RefundAll(wctx, request(nil, 0, 0, true))
 		require.NoError(t, err)
-		require.Equal(t, len(msgs), int(resp.Pagination.Total))
+		require.Equal(t, len(refunds), int(resp.Pagination.Total))
 		require.ElementsMatch(t,
-			nullify.Fill(msgs),
+			nullify.Fill(refunds),
 			nullify.Fill(resp.Refund),
 		)
 	})
 	t.Run("InvalidRequest", func(t *testing.T) {
-		_, err := keeper.RefundAll(wctx, nil)
+		_, err := querier.RefundAll(wctx, nil)
 		require.ErrorIs(t, err, status.Error(codes.InvalidArgument, "invalid request"))
 	})
 }

--- a/x/slashrefund/keeper/grpc_query_unbonding_deposit.go
+++ b/x/slashrefund/keeper/grpc_query_unbonding_deposit.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func (k Keeper) UnbondingDepositAll(c context.Context, req *types.QueryAllUnbondingDepositRequest) (*types.QueryAllUnbondingDepositResponse, error) {
+func (k Querier) UnbondingDepositAll(c context.Context, req *types.QueryAllUnbondingDepositRequest) (*types.QueryAllUnbondingDepositResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
@@ -39,7 +39,7 @@ func (k Keeper) UnbondingDepositAll(c context.Context, req *types.QueryAllUnbond
 	return &types.QueryAllUnbondingDepositResponse{UnbondingDeposit: unbondingDeposits, Pagination: pageRes}, nil
 }
 
-func (k Keeper) UnbondingDeposit(c context.Context, req *types.QueryGetUnbondingDepositRequest) (*types.QueryGetUnbondingDepositResponse, error) {
+func (k Querier) UnbondingDeposit(c context.Context, req *types.QueryGetUnbondingDepositRequest) (*types.QueryGetUnbondingDepositResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}

--- a/x/slashrefund/keeper/grpc_query_unbonding_deposit.go
+++ b/x/slashrefund/keeper/grpc_query_unbonding_deposit.go
@@ -60,7 +60,7 @@ func (k Querier) UnbondingDeposit(c context.Context, req *types.QueryGetUnbondin
 		valAddr,
 	)
 	if !found {
-		return nil, status.Error(codes.NotFound, "unbonding deposit not found")
+		return nil, status.Error(codes.NotFound, "not found")
 	}
 
 	return &types.QueryGetUnbondingDepositResponse{UnbondingDeposit: val}, nil

--- a/x/slashrefund/keeper/grpc_query_unbonding_deposit_test.go
+++ b/x/slashrefund/keeper/grpc_query_unbonding_deposit_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestUnbondingDepositQuerySingle(t *testing.T) {
-
 	s := SetupTestSuite(t, 100)
 	srApp, ctx, testAddrs, valAddrs, querier := s.srApp, s.ctx, s.testAddrs, s.valAddrs, s.querier
 	wctx := sdk.WrapSDKContext(ctx)
@@ -81,7 +80,6 @@ func TestUnbondingDepositQuerySingle(t *testing.T) {
 }
 
 func TestUnbondingDepositQueryPaginated(t *testing.T) {
-
 	s := SetupTestSuite(t, 100)
 	srApp, ctx, querier := s.srApp, s.ctx, s.querier
 	wctx := sdk.WrapSDKContext(ctx)

--- a/x/slashrefund/keeper/handle_refunds_from_slash_test.go
+++ b/x/slashrefund/keeper/handle_refunds_from_slash_test.go
@@ -19,38 +19,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Default initial state for all test. It creates two validators with a specified power. 
+// Default initial state for all test. It creates two validators with a specified power.
 func bootstrapRefundTest(t *testing.T, power int64) *KeeperTestSuite {
-
-	srApp, ctx := testsuite.CreateTestApp(false)
-
-	units := srApp.StakingKeeper.PowerReduction(ctx).Int64()
-
-	initAmt := sdk.NewInt(int64(1000 * units))
-	testAddrs, pubks := CreateNTestAccounts(srApp, ctx, 5, initAmt)
-
-	selfDelegation := sdk.NewInt(power * units)
-
-	// create 2 validators with consensous power equal to input power
-	sth := teststaking.NewHelper(t, ctx, srApp.StakingKeeper)
-
-	valAddrs := make([]sdk.ValAddress, 0, 2)
-
-	for i := 0; i < 2; i++ {
-		sth.CreateValidatorWithValPower(sdk.ValAddress(testAddrs[i]), pubks[i], selfDelegation.QuoRaw(units).Int64(), true)
-		validator, found := srApp.StakingKeeper.GetValidatorByConsAddr(ctx, sdk.ConsAddress(testAddrs[i]))
-		require.True(t, found)
-		valAddr := validator.GetOperator()
-		sd, found := srApp.StakingKeeper.GetDelegation(ctx, testAddrs[i], valAddr)
-		require.True(t, found)
-		require.Equal(t, selfDelegation, sd.Shares.TruncateInt())
-		valAddrs = append(valAddrs, valAddr)
-	}
-
-	s := KeeperTestSuite{}
-	s.srApp, s.ctx, s.units, s.testAddrs, s.valAddrs, s.selfDelegation, s.t = srApp, ctx, units, testAddrs, valAddrs, selfDelegation, t
-
-	return &s
+	return SetupTestSuite(t, power)
 }
 
 func defaultTestValues() (power int64, slashFactor sdk.Dec, slashAmt sdk.Int, depositAmt sdk.Int, infractionHeight int64, slashTime time.Time) {

--- a/x/slashrefund/keeper/keeper_test.go
+++ b/x/slashrefund/keeper/keeper_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/made-in-block/slash-refund/app"
 	"github.com/made-in-block/slash-refund/testutil/testsuite"
+	"github.com/made-in-block/slash-refund/x/slashrefund/keeper"
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
 
 	"github.com/stretchr/testify/require"
@@ -20,6 +21,7 @@ type KeeperTestSuite struct {
 	testAddrs      []sdk.AccAddress
 	valAddrs       []sdk.ValAddress
 	selfDelegation sdk.Int
+	querier        keeper.Querier
 	t              *testing.T
 }
 
@@ -52,7 +54,7 @@ func SetupTestSuite(t *testing.T, power int64) *KeeperTestSuite {
 	}
 
 	s := KeeperTestSuite{}
-	s.srApp, s.ctx, s.units, s.testAddrs, s.valAddrs, s.selfDelegation, s.t = srApp, ctx, units, testAddrs, valAddrs, selfDelegation, t
+	s.srApp, s.ctx, s.units, s.testAddrs, s.valAddrs, s.selfDelegation, s.querier, s.t = srApp, ctx, units, testAddrs, valAddrs, selfDelegation, keeper.Querier{Keeper: srApp.SlashrefundKeeper}, t
 
 	return &s
 }

--- a/x/slashrefund/keeper/keeper_test.go
+++ b/x/slashrefund/keeper/keeper_test.go
@@ -4,8 +4,12 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/staking/teststaking"
+
 	"github.com/made-in-block/slash-refund/app"
+	"github.com/made-in-block/slash-refund/testutil/testsuite"
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,6 +21,40 @@ type KeeperTestSuite struct {
 	valAddrs       []sdk.ValAddress
 	selfDelegation sdk.Int
 	t              *testing.T
+}
+
+// Default initial state for all test. It creates two validators with a specified power.
+func SetupTestSuite(t *testing.T, power int64) *KeeperTestSuite {
+
+	srApp, ctx := testsuite.CreateTestApp(false)
+
+	units := srApp.StakingKeeper.PowerReduction(ctx).Int64()
+
+	initAmt := sdk.NewInt(int64(1000 * units))
+	testAddrs, pubks := CreateNTestAccounts(srApp, ctx, 5, initAmt)
+
+	selfDelegation := sdk.NewInt(power * units)
+
+	// create 2 validators with consensous power equal to input power
+	sth := teststaking.NewHelper(t, ctx, srApp.StakingKeeper)
+
+	valAddrs := make([]sdk.ValAddress, 0, 2)
+
+	for i := 0; i < 2; i++ {
+		sth.CreateValidatorWithValPower(sdk.ValAddress(testAddrs[i]), pubks[i], selfDelegation.QuoRaw(units).Int64(), true)
+		validator, found := srApp.StakingKeeper.GetValidatorByConsAddr(ctx, sdk.ConsAddress(testAddrs[i]))
+		require.True(t, found)
+		valAddr := validator.GetOperator()
+		sd, found := srApp.StakingKeeper.GetDelegation(ctx, testAddrs[i], valAddr)
+		require.True(t, found)
+		require.Equal(t, selfDelegation, sd.Shares.TruncateInt())
+		valAddrs = append(valAddrs, valAddr)
+	}
+
+	s := KeeperTestSuite{}
+	s.srApp, s.ctx, s.units, s.testAddrs, s.valAddrs, s.selfDelegation, s.t = srApp, ctx, units, testAddrs, valAddrs, selfDelegation, t
+
+	return &s
 }
 
 func (s KeeperTestSuite) RequireNoRefund(addr sdk.AccAddress, valAddr sdk.ValAddress) {

--- a/x/slashrefund/keeper/refund_test.go
+++ b/x/slashrefund/keeper/refund_test.go
@@ -2,7 +2,6 @@ package keeper_test
 
 import (
 	//"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
@@ -14,9 +13,6 @@ import (
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
 	"github.com/stretchr/testify/require"
 )
-
-// Prevent strconv unused error
-var _ = strconv.IntSize
 
 func createNRefund(keeper *keeper.Keeper, ctx sdk.Context, n int) []types.Refund {
 


### PR DESCRIPTION
This PR:
  - modifies all query `Keeper`' methods in `Querier` methods;
  - updates the grpc-query unit tests of `keeper` package;
  - moves KeeperTestSuite initialization into  `keeper_test.go` file and adds the querier to the suit.