### PR TITLE
Fix keeper method to correctly get the unbonding deposits of specific validator 

### DIFF
--- a/x/slashrefund/keeper/grpc_query_unbonding_deposit_test.go
+++ b/x/slashrefund/keeper/grpc_query_unbonding_deposit_test.go
@@ -19,13 +19,13 @@ func TestUnbondingDepositQuerySingle(t *testing.T) {
 	srApp, ctx, testAddrs, valAddrs, querier := s.srApp, s.ctx, s.testAddrs, s.valAddrs, s.querier
 	wctx := sdk.WrapSDKContext(ctx)
 
-	ubdep1 := types.NewUnbondingDeposit(testAddrs[0], valAddrs[0], 10, time.Unix(10, 0), sdk.NewInt(100))
-	entry2 := types.NewUnbondingDepositEntry(20, time.Unix(20, 0), sdk.NewInt(200))
+	ubdep1 := types.NewUnbondingDeposit(testAddrs[0], valAddrs[0], 10, time.Unix(10, 0).UTC(), sdk.NewInt(100))
+	entry2 := types.NewUnbondingDepositEntry(20, time.Unix(20, 0).UTC(), sdk.NewInt(200))
 	ubdep1.Entries = append(ubdep1.Entries, entry2)
 	srApp.SlashrefundKeeper.SetUnbondingDeposit(ctx, ubdep1)
 
-	ubdep2 := types.NewUnbondingDeposit(testAddrs[1], valAddrs[0], 0, time.Unix(30, 0), sdk.NewInt(300))
-	entry2 = types.NewUnbondingDepositEntry(40, time.Unix(40, 0), sdk.NewInt(400))
+	ubdep2 := types.NewUnbondingDeposit(testAddrs[1], valAddrs[0], 0, time.Unix(30, 0).UTC(), sdk.NewInt(300))
+	entry2 = types.NewUnbondingDepositEntry(40, time.Unix(40, 0).UTC(), sdk.NewInt(400))
 	ubdep2.Entries = append(ubdep2.Entries, entry2)
 	srApp.SlashrefundKeeper.SetUnbondingDeposit(ctx, ubdep2)
 

--- a/x/slashrefund/keeper/unbonding_deposit.go
+++ b/x/slashrefund/keeper/unbonding_deposit.go
@@ -109,11 +109,11 @@ func (k Keeper) GetUnbondingDepositsFromValidator(ctx sdk.Context, valAddr sdk.V
 	iterator := sdk.KVStorePrefixIterator(store, keyspace)
 	defer iterator.Close()
 
-	var ubd types.UnbondingDeposit
-
-	defer iterator.Close()
-
 	for ; iterator.Valid(); iterator.Next() {
+
+		//reset ubd
+		var ubd types.UnbondingDeposit
+
 		// rearrange key
 		key2 := iterator.Key()
 		key := types.GetUBDKeyFromValIndexKey(key2)

--- a/x/slashrefund/keeper/unbonding_deposit_test.go
+++ b/x/slashrefund/keeper/unbonding_deposit_test.go
@@ -1,12 +1,12 @@
 package keeper_test
 
 import (
+	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/made-in-block/slash-refund/testutil/nullify"
 	"github.com/made-in-block/slash-refund/x/slashrefund/keeper"
 	"github.com/made-in-block/slash-refund/x/slashrefund/testslashrefund"
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
@@ -14,12 +14,17 @@ import (
 )
 
 func createNEntries(n int) []types.UnbondingDepositEntry {
-	creationHeight := n
-	completionTime := time.Now().Add(time.Duration(n * 1000))
-	balance := sdk.NewInt(1000000)
+
 	var entries []types.UnbondingDepositEntry
 	for i := 0; i < n; i++ {
-		entry := types.NewUnbondingDepositEntry(int64(creationHeight), completionTime, balance)
+		rand.Seed(time.Now().UnixNano())
+		r := rand.Int63n(1000000)
+		creationHeight := r
+		completionTime := time.Now().Add(time.Duration(r)).UTC()
+		balance := sdk.NewInt(r)
+		initBalance := balance.AddRaw(rand.Int63n(1000000))
+		entry := types.NewUnbondingDepositEntry(int64(creationHeight), completionTime, initBalance)
+		entry.Balance = balance
 		entries = append(entries, entry)
 	}
 	return entries
@@ -28,25 +33,19 @@ func createNEntries(n int) []types.UnbondingDepositEntry {
 func createNUnbondingDeposit(keeper *keeper.Keeper, ctx sdk.Context, n int, nentries int) []types.UnbondingDeposit {
 	items := make([]types.UnbondingDeposit, n)
 	for i := range items {
-		depPubk := secp256k1.GenPrivKey().PubKey()
-		depAddr := sdk.AccAddress(depPubk.Address())
-		valPubk := secp256k1.GenPrivKey().PubKey()
-		valAddr := sdk.ValAddress(valPubk.Address())
-		items[i].DepositorAddress = depAddr.String()
-		items[i].ValidatorAddress = valAddr.String()
+		items[i].DepositorAddress = sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
+		items[i].ValidatorAddress = sdk.ValAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
 		items[i].Entries = createNEntries(nentries)
 		keeper.SetUnbondingDeposit(ctx, items[i])
 	}
 	return items
 }
 
-func createNUnbondingDepositForValidator(keeper *keeper.Keeper, ctx sdk.Context, n int, nentries int, valAddr sdk.ValAddress) []types.UnbondingDeposit {
+func createNUnbondingDepositForValidator(keeper *keeper.Keeper, ctx sdk.Context, n int, nentries int, valAddress string) []types.UnbondingDeposit {
 	items := make([]types.UnbondingDeposit, n)
 	for i := range items {
-		depPubk := secp256k1.GenPrivKey().PubKey()
-		depAddr := sdk.AccAddress(depPubk.Address())
-		items[i].DepositorAddress = depAddr.String()
-		items[i].ValidatorAddress = valAddr.String()
+		items[i].DepositorAddress = sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
+		items[i].ValidatorAddress = valAddress
 		items[i].Entries = createNEntries(nentries)
 		keeper.SetUnbondingDeposit(ctx, items[i])
 	}
@@ -55,18 +54,18 @@ func createNUnbondingDepositForValidator(keeper *keeper.Keeper, ctx sdk.Context,
 
 func TestUnbondingDepositGet(t *testing.T) {
 	keeper, ctx := testslashrefund.NewTestKeeper(t)
-	items := createNUnbondingDeposit(keeper, ctx, 10, 3)
+	items := createNUnbondingDeposit(keeper, ctx, 10, 5)
 	for _, item := range items {
 		depAddr, _ := sdk.AccAddressFromBech32(item.DepositorAddress)
 		valAddr, _ := sdk.ValAddressFromBech32(item.ValidatorAddress)
 		got, found := keeper.GetUnbondingDeposit(ctx, depAddr, valAddr)
 		require.True(t, found)
-		require.Equal(t, nullify.Fill(&item), nullify.Fill(&got))
+		require.Equal(t, item, got)
 	}
 }
 func TestUnbondingDepositRemove(t *testing.T) {
 	keeper, ctx := testslashrefund.NewTestKeeper(t)
-	items := createNUnbondingDeposit(keeper, ctx, 10, 3)
+	items := createNUnbondingDeposit(keeper, ctx, 10, 5)
 	for _, item := range items {
 		keeper.RemoveUnbondingDeposit(ctx, item)
 		depAddr, _ := sdk.AccAddressFromBech32(item.DepositorAddress)
@@ -81,18 +80,22 @@ func TestUnbondingDepositRemove(t *testing.T) {
 
 func TestUnbondingDepositGetAll(t *testing.T) {
 	keeper, ctx := testslashrefund.NewTestKeeper(t)
-	items := createNUnbondingDeposit(keeper, ctx, 10, 3)
-	require.ElementsMatch(t,
-		nullify.Fill(items),
-		nullify.Fill(keeper.GetAllUnbondingDeposit(ctx)),
-	)
+	items := createNUnbondingDeposit(keeper, ctx, 10, 5)
+	require.ElementsMatch(t, items, keeper.GetAllUnbondingDeposit(ctx))
 }
 
 func TestUnbondingDepositGetUnbondingDepositsFromValidator(t *testing.T) {
 	keeper, ctx := testslashrefund.NewTestKeeper(t)
-	valPubk := secp256k1.GenPrivKey().PubKey()
-	valAddr := sdk.ValAddress(valPubk.Address())
-	items := createNUnbondingDepositForValidator(keeper, ctx, 10, 3, valAddr)
-	got := keeper.GetUnbondingDepositsFromValidator(ctx, valAddr)
-	require.ElementsMatch(t, nullify.Fill(items), nullify.Fill(got))
+	valAddress0 := "cosmosvaloper12h6y5kn64xh6d6wsnw7098kc8k9kp2u6m03was"
+	items0 := createNUnbondingDepositForValidator(keeper, ctx, 10, 5, valAddress0)
+	valAddress1 := "cosmosvaloper1e8wanntwnsnvrz7eaj82hzhhp5lrz3gsfzkfly"
+	items1 := createNUnbondingDepositForValidator(keeper, ctx, 10, 5, valAddress1)
+	valAddr0, err := sdk.ValAddressFromBech32(valAddress0)
+	require.NoError(t, err)
+	valAddr1, err := sdk.ValAddressFromBech32(valAddress1)
+	require.NoError(t, err)
+	got0 := keeper.GetUnbondingDepositsFromValidator(ctx, valAddr0)
+	require.ElementsMatch(t, items0, got0)
+	got1 := keeper.GetUnbondingDepositsFromValidator(ctx, valAddr1)
+	require.ElementsMatch(t, items1, got1)
 }


### PR DESCRIPTION
This PR:
  - fixes the keeper method `GetUnbondingDepositsFromValidator()` to get unbonding deposits of specific validator;
  - adds a unit test for keeper method `RefundFromSlash()` which takes into account more eligible unbonding deposits;
  - updates the keeper test `TestUnbondingDepositQuerySingle()`.