### PR TITLE
Remove nullify from keeper unit tests

### DIFF
--- a/x/slashrefund/keeper/deposit_pool_test.go
+++ b/x/slashrefund/keeper/deposit_pool_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/made-in-block/slash-refund/testutil/nullify"
 	"github.com/made-in-block/slash-refund/x/slashrefund/keeper"
 	"github.com/made-in-block/slash-refund/x/slashrefund/testslashrefund"
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
@@ -19,6 +18,7 @@ func createNDepositPool(keeper *keeper.Keeper, ctx sdk.Context, n int) []types.D
 		valAddr := sdk.ValAddress(valPubk.Address())
 		items[i].OperatorAddress = valAddr.String()
 		items[i].Shares = sdk.NewDec(int64(1000 * i))
+		items[i].Tokens = sdk.NewInt64Coin("stake", int64(1000*i))
 		keeper.SetDepositPool(ctx, items[i])
 	}
 	return items
@@ -31,7 +31,7 @@ func TestDepositPoolGet(t *testing.T) {
 		valAddr, _ := sdk.ValAddressFromBech32(item.OperatorAddress)
 		rst, found := keeper.GetDepositPool(ctx, valAddr)
 		require.True(t, found)
-		require.Equal(t, nullify.Fill(&item), nullify.Fill(&rst))
+		require.Equal(t, item, rst)
 	}
 }
 func TestDepositPoolRemove(t *testing.T) {
@@ -48,8 +48,5 @@ func TestDepositPoolRemove(t *testing.T) {
 func TestDepositPoolGetAll(t *testing.T) {
 	keeper, ctx := testslashrefund.NewTestKeeper(t)
 	items := createNDepositPool(keeper, ctx, 10)
-	require.ElementsMatch(t,
-		nullify.Fill(items),
-		nullify.Fill(keeper.GetAllDepositPool(ctx)),
-	)
+	require.ElementsMatch(t, items, keeper.GetAllDepositPool(ctx))
 }

--- a/x/slashrefund/keeper/deposit_test.go
+++ b/x/slashrefund/keeper/deposit_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/made-in-block/slash-refund/testutil/nullify"
 	"github.com/made-in-block/slash-refund/x/slashrefund/keeper"
 	"github.com/made-in-block/slash-refund/x/slashrefund/testslashrefund"
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
@@ -50,10 +49,7 @@ func TestDepositGet(t *testing.T) {
 		valAddr, _ := sdk.ValAddressFromBech32(deposit.ValidatorAddress)
 		rst, found := keeper.GetDeposit(ctx, depAddr, valAddr)
 		require.True(t, found)
-		require.Equal(t,
-			nullify.Fill(&deposit),
-			nullify.Fill(&rst),
-		)
+		require.Equal(t, deposit, rst)
 	}
 }
 func TestDepositRemove(t *testing.T) {
@@ -71,24 +67,13 @@ func TestDepositRemove(t *testing.T) {
 func TestDepositGetAll(t *testing.T) {
 	keeper, ctx := testslashrefund.NewTestKeeper(t)
 	items := createNDeposit(keeper, ctx, 10)
-	require.ElementsMatch(t,
-		nullify.Fill(items),
-		nullify.Fill(keeper.GetAllDeposit(ctx)),
-	)
+	require.ElementsMatch(t, items, keeper.GetAllDeposit(ctx))
 }
 
 func TestGetValidatorDeposits(t *testing.T) {
 	keeper, ctx := testslashrefund.NewTestKeeper(t)
-	items, valAddr := createNDepositForValidator(keeper, ctx, 10)
-	require.ElementsMatch(t,
-		nullify.Fill(items),
-		nullify.Fill(keeper.GetValidatorDeposits(ctx, valAddr)),
-	)
-	_ = createNDeposit(keeper, ctx, 20)
-	deposits := keeper.GetValidatorDeposits(ctx, valAddr)
-	require.ElementsMatch(t,
-		nullify.Fill(items),
-		nullify.Fill(deposits),
-	)
-
+	items0, valAddr0 := createNDepositForValidator(keeper, ctx, 10)
+	items1, valAddr1 := createNDepositForValidator(keeper, ctx, 10)
+	require.ElementsMatch(t, items0, keeper.GetValidatorDeposits(ctx, valAddr0))
+	require.ElementsMatch(t, items1, keeper.GetValidatorDeposits(ctx, valAddr1))
 }

--- a/x/slashrefund/keeper/grpc_query_deposit_pool_test.go
+++ b/x/slashrefund/keeper/grpc_query_deposit_pool_test.go
@@ -9,7 +9,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/made-in-block/slash-refund/testutil/nullify"
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
 )
 
@@ -65,10 +64,7 @@ func TestDepositPoolQuerySingle(t *testing.T) {
 				require.ErrorIs(t, err, tc.err)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t,
-					nullify.Fill(tc.response),
-					nullify.Fill(response),
-				)
+				require.Equal(t, tc.response, response)
 			}
 		})
 	}
@@ -97,10 +93,7 @@ func TestDepositPoolQueryPaginated(t *testing.T) {
 			resp, err := querier.DepositPoolAll(wctx, request(nil, uint64(i), uint64(step), false))
 			require.NoError(t, err)
 			require.LessOrEqual(t, len(resp.DepositPool), step)
-			require.Subset(t,
-				nullify.Fill(depPools),
-				nullify.Fill(resp.DepositPool),
-			)
+			require.Subset(t, depPools, resp.DepositPool)
 		}
 	})
 	t.Run("ByKey", func(t *testing.T) {
@@ -110,10 +103,7 @@ func TestDepositPoolQueryPaginated(t *testing.T) {
 			resp, err := querier.DepositPoolAll(wctx, request(next, 0, uint64(step), false))
 			require.NoError(t, err)
 			require.LessOrEqual(t, len(resp.DepositPool), step)
-			require.Subset(t,
-				nullify.Fill(depPools),
-				nullify.Fill(resp.DepositPool),
-			)
+			require.Subset(t, depPools, resp.DepositPool)
 			next = resp.Pagination.NextKey
 		}
 	})
@@ -121,10 +111,7 @@ func TestDepositPoolQueryPaginated(t *testing.T) {
 		resp, err := querier.DepositPoolAll(wctx, request(nil, 0, 0, true))
 		require.NoError(t, err)
 		require.Equal(t, len(depPools), int(resp.Pagination.Total))
-		require.ElementsMatch(t,
-			nullify.Fill(depPools),
-			nullify.Fill(resp.DepositPool),
-		)
+		require.ElementsMatch(t, depPools, resp.DepositPool)
 	})
 	t.Run("Invalid Request", func(t *testing.T) {
 		_, err := querier.DepositPoolAll(wctx, nil)

--- a/x/slashrefund/keeper/grpc_query_deposit_test.go
+++ b/x/slashrefund/keeper/grpc_query_deposit_test.go
@@ -5,7 +5,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
-	"github.com/made-in-block/slash-refund/testutil/nullify"
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -66,10 +65,7 @@ func TestDepositQuerySingle(t *testing.T) {
 				require.ErrorIs(t, err, tc.err)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t,
-					nullify.Fill(tc.response),
-					nullify.Fill(response),
-				)
+				require.Equal(t, tc.response, response)
 			}
 		})
 	}
@@ -98,10 +94,7 @@ func TestDepositQueryPaginated(t *testing.T) {
 			resp, err := querier.DepositAll(wctx, request(nil, uint64(i), uint64(step), false))
 			require.NoError(t, err)
 			require.LessOrEqual(t, len(resp.Deposit), step)
-			require.Subset(t,
-				nullify.Fill(deposits),
-				nullify.Fill(resp.Deposit),
-			)
+			require.Subset(t, deposits, resp.Deposit)
 		}
 	})
 	t.Run("ByKey", func(t *testing.T) {
@@ -111,10 +104,7 @@ func TestDepositQueryPaginated(t *testing.T) {
 			resp, err := querier.DepositAll(wctx, request(next, 0, uint64(step), false))
 			require.NoError(t, err)
 			require.LessOrEqual(t, len(resp.Deposit), step)
-			require.Subset(t,
-				nullify.Fill(deposits),
-				nullify.Fill(resp.Deposit),
-			)
+			require.Subset(t, deposits, resp.Deposit)
 			next = resp.Pagination.NextKey
 		}
 	})
@@ -122,10 +112,7 @@ func TestDepositQueryPaginated(t *testing.T) {
 		resp, err := querier.DepositAll(wctx, request(nil, 0, 0, true))
 		require.NoError(t, err)
 		require.Equal(t, len(deposits), int(resp.Pagination.Total))
-		require.ElementsMatch(t,
-			nullify.Fill(deposits),
-			nullify.Fill(resp.Deposit),
-		)
+		require.ElementsMatch(t, deposits, resp.Deposit)
 	})
 	t.Run("InvalidRequest", func(t *testing.T) {
 		_, err := querier.DepositAll(wctx, nil)

--- a/x/slashrefund/keeper/grpc_query_refund_pool_test.go
+++ b/x/slashrefund/keeper/grpc_query_refund_pool_test.go
@@ -9,7 +9,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/made-in-block/slash-refund/testutil/nullify"
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
 )
 
@@ -65,10 +64,7 @@ func TestRefundPoolQuerySingle(t *testing.T) {
 				require.ErrorIs(t, err, tc.err)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t,
-					nullify.Fill(tc.response),
-					nullify.Fill(response),
-				)
+				require.Equal(t, tc.response, response)
 			}
 		})
 	}
@@ -97,10 +93,7 @@ func TestRefundPoolQueryPaginated(t *testing.T) {
 			resp, err := querier.RefundPoolAll(wctx, request(nil, uint64(i), uint64(step), false))
 			require.NoError(t, err)
 			require.LessOrEqual(t, len(resp.RefundPool), step)
-			require.Subset(t,
-				nullify.Fill(refPools),
-				nullify.Fill(resp.RefundPool),
-			)
+			require.Subset(t, refPools, resp.RefundPool)
 		}
 	})
 	t.Run("ByKey", func(t *testing.T) {
@@ -110,10 +103,7 @@ func TestRefundPoolQueryPaginated(t *testing.T) {
 			resp, err := querier.RefundPoolAll(wctx, request(next, 0, uint64(step), false))
 			require.NoError(t, err)
 			require.LessOrEqual(t, len(resp.RefundPool), step)
-			require.Subset(t,
-				nullify.Fill(refPools),
-				nullify.Fill(resp.RefundPool),
-			)
+			require.Subset(t, refPools, resp.RefundPool)
 			next = resp.Pagination.NextKey
 		}
 	})
@@ -121,10 +111,7 @@ func TestRefundPoolQueryPaginated(t *testing.T) {
 		resp, err := querier.RefundPoolAll(wctx, request(nil, 0, 0, true))
 		require.NoError(t, err)
 		require.Equal(t, len(refPools), int(resp.Pagination.Total))
-		require.ElementsMatch(t,
-			nullify.Fill(refPools),
-			nullify.Fill(resp.RefundPool),
-		)
+		require.ElementsMatch(t, refPools, resp.RefundPool)
 	})
 	t.Run("InvalidRequest", func(t *testing.T) {
 		_, err := querier.RefundPoolAll(wctx, nil)

--- a/x/slashrefund/keeper/grpc_query_refund_test.go
+++ b/x/slashrefund/keeper/grpc_query_refund_test.go
@@ -9,7 +9,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/made-in-block/slash-refund/testutil/nullify"
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
 )
 
@@ -65,10 +64,7 @@ func TestRefundQuerySingle(t *testing.T) {
 				require.ErrorIs(t, err, tc.err)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t,
-					nullify.Fill(tc.response),
-					nullify.Fill(response),
-				)
+				require.Equal(t, tc.response, response)
 			}
 		})
 	}
@@ -97,10 +93,7 @@ func TestRefundQueryPaginated(t *testing.T) {
 			resp, err := querier.RefundAll(wctx, request(nil, uint64(i), uint64(step), false))
 			require.NoError(t, err)
 			require.LessOrEqual(t, len(resp.Refund), step)
-			require.Subset(t,
-				nullify.Fill(refunds),
-				nullify.Fill(resp.Refund),
-			)
+			require.Subset(t, refunds, resp.Refund)
 		}
 	})
 	t.Run("ByKey", func(t *testing.T) {
@@ -110,10 +103,7 @@ func TestRefundQueryPaginated(t *testing.T) {
 			resp, err := querier.RefundAll(wctx, request(next, 0, uint64(step), false))
 			require.NoError(t, err)
 			require.LessOrEqual(t, len(resp.Refund), step)
-			require.Subset(t,
-				nullify.Fill(refunds),
-				nullify.Fill(resp.Refund),
-			)
+			require.Subset(t, refunds, resp.Refund)
 			next = resp.Pagination.NextKey
 		}
 	})
@@ -121,10 +111,7 @@ func TestRefundQueryPaginated(t *testing.T) {
 		resp, err := querier.RefundAll(wctx, request(nil, 0, 0, true))
 		require.NoError(t, err)
 		require.Equal(t, len(refunds), int(resp.Pagination.Total))
-		require.ElementsMatch(t,
-			nullify.Fill(refunds),
-			nullify.Fill(resp.Refund),
-		)
+		require.ElementsMatch(t, refunds, resp.Refund)
 	})
 	t.Run("InvalidRequest", func(t *testing.T) {
 		_, err := querier.RefundAll(wctx, nil)

--- a/x/slashrefund/keeper/grpc_query_unbonding_deposit_test.go
+++ b/x/slashrefund/keeper/grpc_query_unbonding_deposit_test.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/made-in-block/slash-refund/testutil/nullify"
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
 )
 
@@ -70,10 +69,7 @@ func TestUnbondingDepositQuerySingle(t *testing.T) {
 				require.ErrorIs(t, err, tc.err)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t,
-					nullify.Fill(tc.response),
-					nullify.Fill(response),
-				)
+				require.Equal(t, tc.response, response)
 			}
 		})
 	}
@@ -102,10 +98,7 @@ func TestUnbondingDepositQueryPaginated(t *testing.T) {
 			resp, err := querier.UnbondingDepositAll(wctx, request(nil, uint64(i), uint64(step), false))
 			require.NoError(t, err)
 			require.LessOrEqual(t, len(resp.UnbondingDeposit), step)
-			require.Subset(t,
-				nullify.Fill(ubds),
-				nullify.Fill(resp.UnbondingDeposit),
-			)
+			require.Subset(t, ubds, resp.UnbondingDeposit)
 		}
 	})
 	t.Run("ByKey", func(t *testing.T) {
@@ -115,10 +108,7 @@ func TestUnbondingDepositQueryPaginated(t *testing.T) {
 			resp, err := querier.UnbondingDepositAll(wctx, request(next, 0, uint64(step), false))
 			require.NoError(t, err)
 			require.LessOrEqual(t, len(resp.UnbondingDeposit), step)
-			require.Subset(t,
-				nullify.Fill(ubds),
-				nullify.Fill(resp.UnbondingDeposit),
-			)
+			require.Subset(t, ubds, resp.UnbondingDeposit)
 			next = resp.Pagination.NextKey
 		}
 	})
@@ -126,10 +116,7 @@ func TestUnbondingDepositQueryPaginated(t *testing.T) {
 		resp, err := querier.UnbondingDepositAll(wctx, request(nil, 0, 0, true))
 		require.NoError(t, err)
 		require.Equal(t, len(ubds), int(resp.Pagination.Total))
-		require.ElementsMatch(t,
-			nullify.Fill(ubds),
-			nullify.Fill(resp.UnbondingDeposit),
-		)
+		require.ElementsMatch(t, ubds, resp.UnbondingDeposit)
 	})
 	t.Run("InvalidRequest", func(t *testing.T) {
 		_, err := querier.UnbondingDepositAll(wctx, nil)

--- a/x/slashrefund/keeper/refund_pool_test.go
+++ b/x/slashrefund/keeper/refund_pool_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/made-in-block/slash-refund/testutil/nullify"
 	"github.com/made-in-block/slash-refund/x/slashrefund/keeper"
 	"github.com/made-in-block/slash-refund/x/slashrefund/testslashrefund"
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
@@ -18,9 +17,8 @@ func createNRefundPool(keeper *keeper.Keeper, ctx sdk.Context, n int) []types.Re
 		valPubk := secp256k1.GenPrivKey().PubKey()
 		valAddr := sdk.ValAddress(valPubk.Address())
 		items[i].OperatorAddress = valAddr.String()
-		items[i].Shares = sdk.ZeroDec()
-		items[i].Tokens.Amount = sdk.ZeroInt()
-		items[i].Tokens.Denom = keeper.AllowedTokens(ctx)[0]
+		items[i].Shares = sdk.NewDec(int64(1000 * i))
+		items[i].Tokens = sdk.NewInt64Coin("stake", int64(1000*i))
 		keeper.SetRefundPool(ctx, items[i])
 	}
 	return items
@@ -33,10 +31,7 @@ func TestRefundPoolGet(t *testing.T) {
 		valAddr, _ := sdk.ValAddressFromBech32(item.OperatorAddress)
 		rst, found := keeper.GetRefundPool(ctx, valAddr)
 		require.True(t, found)
-		require.Equal(t,
-			nullify.Fill(&item),
-			nullify.Fill(&rst),
-		)
+		require.Equal(t, item, rst)
 	}
 }
 
@@ -52,10 +47,7 @@ func TestUpdateRefundPool(t *testing.T) {
 
 		rst, found := keeper.GetRefundPool(ctx, valAddr)
 		require.True(t, found)
-		require.Equal(t,
-			nullify.Fill(&refPool),
-			nullify.Fill(&rst),
-		)
+		require.Equal(t, refPool, rst)
 	}
 }
 
@@ -73,8 +65,5 @@ func TestRefundPoolRemove(t *testing.T) {
 func TestRefundPoolGetAll(t *testing.T) {
 	keeper, ctx := testslashrefund.NewTestKeeper(t)
 	items := createNRefundPool(keeper, ctx, 10)
-	require.ElementsMatch(t,
-		nullify.Fill(items),
-		nullify.Fill(keeper.GetAllRefundPool(ctx)),
-	)
+	require.ElementsMatch(t, items, keeper.GetAllRefundPool(ctx))
 }

--- a/x/slashrefund/keeper/refund_test.go
+++ b/x/slashrefund/keeper/refund_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/made-in-block/slash-refund/testutil/nullify"
 	"github.com/made-in-block/slash-refund/x/slashrefund/keeper"
 	"github.com/made-in-block/slash-refund/x/slashrefund/testslashrefund"
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
@@ -24,7 +23,7 @@ func createNRefund(keeper *keeper.Keeper, ctx sdk.Context, n int) []types.Refund
 		valAddr := sdk.ValAddress(valPubk.Address())
 		items[i].DelegatorAddress = delAddr.String()
 		items[i].ValidatorAddress = valAddr.String()
-		items[i].Shares = sdk.ZeroDec()
+		items[i].Shares = sdk.NewDec(int64(1000 * i))
 		keeper.SetRefund(ctx, items[i])
 	}
 	return items
@@ -38,10 +37,7 @@ func TestRefundGet(t *testing.T) {
 		valAddr, _ := sdk.ValAddressFromBech32(item.ValidatorAddress)
 		rst, found := keeper.GetRefund(ctx, delAddr, valAddr)
 		require.True(t, found)
-		require.Equal(t,
-			nullify.Fill(&item),
-			nullify.Fill(&rst),
-		)
+		require.Equal(t, item, rst)
 	}
 }
 func TestRefundRemove(t *testing.T) {
@@ -60,8 +56,5 @@ func TestRefundRemove(t *testing.T) {
 func TestRefundGetAll(t *testing.T) {
 	keeper, ctx := testslashrefund.NewTestKeeper(t)
 	items := createNRefund(keeper, ctx, 10)
-	require.ElementsMatch(t,
-		nullify.Fill(items),
-		nullify.Fill(keeper.GetAllRefund(ctx)),
-	)
+	require.ElementsMatch(t, items, keeper.GetAllRefund(ctx))
 }


### PR DESCRIPTION
This PR:
  - removes `nullify.Fill()` method in `keeper` unit tests in order to exactly compare set and got entities.