### PR TITLE
Update e2e tests and fix deposit pool query

### DIFF
--- a/testutil/sample/sample.go
+++ b/testutil/sample/sample.go
@@ -8,6 +8,26 @@ import (
 // AccAddress returns a sample account address
 func AccAddress() string {
 	pk := ed25519.GenPrivKey().PubKey()
-	addr := pk.Address()
-	return sdk.AccAddress(addr).String()
+	return sdk.AccAddress(pk.Address()).String()
+}
+
+// AccAddress returns a sample validator address
+func ValAddress() string {
+	pk := ed25519.GenPrivKey().PubKey()
+	return sdk.ValAddress(sdk.AccAddress(pk.Address())).String()
+}
+
+// MockAddress returns "test________________", a string that can be used as account or validator test address.
+func MockAddress() string {
+	return "test________________"
+}
+
+// MockAddress returns "test_______________1", a string that can be used as account or validator test address.
+func MockAddress1() string {
+	return "test_______________1"
+}
+
+// MockAddress returns "test_______________2", a string that can be used as account or validator test address.
+func MockAddress2() string {
+	return "test_______________2"
 }

--- a/x/slashrefund/client/cli/query.go
+++ b/x/slashrefund/client/cli/query.go
@@ -31,8 +31,6 @@ func GetQueryCmd(queryRoute string) *cobra.Command {
 	cmd.AddCommand(CmdShowUnbondingDeposit())
 	cmd.AddCommand(CmdListDepositPool())
 	cmd.AddCommand(CmdShowDepositPool())
-	cmd.AddCommand(CmdListUnbondingDeposit())
-	cmd.AddCommand(CmdShowUnbondingDeposit())
 	cmd.AddCommand(CmdListRefundPool())
 	cmd.AddCommand(CmdShowRefundPool())
 	cmd.AddCommand(CmdListRefund())

--- a/x/slashrefund/client/cli/query.go
+++ b/x/slashrefund/client/cli/query.go
@@ -2,14 +2,10 @@ package cli
 
 import (
 	"fmt"
-	// "strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
-	// "github.com/cosmos/cosmos-sdk/client/flags"
-	// sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
 )
 

--- a/x/slashrefund/client/cli/query_deposit_test.go
+++ b/x/slashrefund/client/cli/query_deposit_test.go
@@ -2,24 +2,21 @@ package cli_test
 
 import (
 	"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 	tmcli "github.com/tendermint/tendermint/libs/cli"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/made-in-block/slash-refund/testutil/network"
-	"github.com/made-in-block/slash-refund/testutil/nullify"
+	"github.com/made-in-block/slash-refund/testutil/sample"
 	"github.com/made-in-block/slash-refund/x/slashrefund/client/cli"
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
 )
-
-// Prevent strconv unused error
-var _ = strconv.IntSize
 
 func networkWithDepositObjects(t *testing.T, n int) (*network.Network, []types.Deposit) {
 	t.Helper()
@@ -29,10 +26,10 @@ func networkWithDepositObjects(t *testing.T, n int) (*network.Network, []types.D
 
 	for i := 0; i < n; i++ {
 		deposit := types.Deposit{
-			DepositorAddress: strconv.Itoa(i),
-			ValidatorAddress: strconv.Itoa(i),
+			DepositorAddress: sample.AccAddress(),
+			ValidatorAddress: sample.ValAddress(),
+			Shares:           sdk.NewDec(int64(100 * (i + 1))),
 		}
-		nullify.Fill(&deposit)
 		state.DepositList = append(state.DepositList, deposit)
 	}
 	buf, err := cfg.Codec.MarshalJSON(&state)
@@ -41,68 +38,10 @@ func networkWithDepositObjects(t *testing.T, n int) (*network.Network, []types.D
 	return network.New(t, cfg), state.DepositList
 }
 
-func TestShowDeposit(t *testing.T) {
-	net, objs := networkWithDepositObjects(t, 2)
-
-	ctx := net.Validators[0].ClientCtx
-	common := []string{
-		fmt.Sprintf("--%s=json", tmcli.OutputFlag),
-	}
-	for _, tc := range []struct {
-		desc               string
-		idAddress          string
-		idValidatorAddress string
-
-		args []string
-		err  error
-		obj  types.Deposit
-	}{
-		{
-			desc:               "found",
-			idAddress:          objs[0].DepositorAddress,
-			idValidatorAddress: objs[0].ValidatorAddress,
-
-			args: common,
-			obj:  objs[0],
-		},
-		{
-			desc:               "not found",
-			idAddress:          strconv.Itoa(100000),
-			idValidatorAddress: strconv.Itoa(100000),
-
-			args: common,
-			err:  status.Error(codes.NotFound, "not found"),
-		},
-	} {
-		t.Run(tc.desc, func(t *testing.T) {
-			args := []string{
-				tc.idAddress,
-				tc.idValidatorAddress,
-			}
-			args = append(args, tc.args...)
-			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdShowDeposit(), args)
-			if tc.err != nil {
-				stat, ok := status.FromError(tc.err)
-				require.True(t, ok)
-				require.ErrorIs(t, stat.Err(), tc.err)
-			} else {
-				require.NoError(t, err)
-				var resp types.QueryGetDepositResponse
-				require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
-				require.NotNil(t, resp.Deposit)
-				require.Equal(t,
-					nullify.Fill(&tc.obj),
-					nullify.Fill(&resp.Deposit),
-				)
-			}
-		})
-	}
-}
-
-func TestListDeposit(t *testing.T) {
+func TestQueryDeposit(t *testing.T) {
 	net, objs := networkWithDepositObjects(t, 5)
-
 	ctx := net.Validators[0].ClientCtx
+
 	request := func(next []byte, offset, limit uint64, total bool) []string {
 		args := []string{
 			fmt.Sprintf("--%s=json", tmcli.OutputFlag),
@@ -118,6 +57,7 @@ func TestListDeposit(t *testing.T) {
 		}
 		return args
 	}
+
 	t.Run("ByOffset", func(t *testing.T) {
 		step := 2
 		for i := 0; i < len(objs); i += step {
@@ -127,12 +67,10 @@ func TestListDeposit(t *testing.T) {
 			var resp types.QueryAllDepositResponse
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.Deposit), step)
-			require.Subset(t,
-				nullify.Fill(objs),
-				nullify.Fill(resp.Deposit),
-			)
+			require.Subset(t, objs, resp.Deposit)
 		}
 	})
+
 	t.Run("ByKey", func(t *testing.T) {
 		step := 2
 		var next []byte
@@ -143,13 +81,11 @@ func TestListDeposit(t *testing.T) {
 			var resp types.QueryAllDepositResponse
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.Deposit), step)
-			require.Subset(t,
-				nullify.Fill(objs),
-				nullify.Fill(resp.Deposit),
-			)
+			require.Subset(t, objs, resp.Deposit)
 			next = resp.Pagination.NextKey
 		}
 	})
+
 	t.Run("Total", func(t *testing.T) {
 		args := request(nil, 0, uint64(len(objs)), true)
 		out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdListDeposit(), args)
@@ -158,9 +94,145 @@ func TestListDeposit(t *testing.T) {
 		require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 		require.NoError(t, err)
 		require.Equal(t, len(objs), int(resp.Pagination.Total))
-		require.ElementsMatch(t,
-			nullify.Fill(objs),
-			nullify.Fill(resp.Deposit),
-		)
+		require.ElementsMatch(t, objs, resp.Deposit)
+	})
+
+	// TESTS: SHOW SINGLE - VALID
+	t.Run("Show-Valid", func(t *testing.T) {
+		common := []string{fmt.Sprintf("--%s=json", tmcli.OutputFlag)}
+		for _, tc := range []struct {
+			desc               string
+			idDepositorAddress string
+			idValidatorAddress string
+			extraArgs          []string
+			obj                types.Deposit
+		}{
+			{
+				desc:               "Found0",
+				idDepositorAddress: objs[0].DepositorAddress,
+				idValidatorAddress: objs[0].ValidatorAddress,
+				extraArgs:          common,
+				obj:                objs[0],
+			},
+			{
+				desc:               "Found1",
+				idDepositorAddress: objs[1].DepositorAddress,
+				idValidatorAddress: objs[1].ValidatorAddress,
+				extraArgs:          common,
+				obj:                objs[1],
+			},
+			{
+				desc:               "Found2",
+				idDepositorAddress: objs[2].DepositorAddress,
+				idValidatorAddress: objs[2].ValidatorAddress,
+				extraArgs:          common,
+				obj:                objs[2],
+			},
+			{
+				desc:               "Found3",
+				idDepositorAddress: objs[3].DepositorAddress,
+				idValidatorAddress: objs[3].ValidatorAddress,
+				extraArgs:          common,
+				obj:                objs[3],
+			},
+			{
+				desc:               "Found4",
+				idDepositorAddress: objs[4].DepositorAddress,
+				idValidatorAddress: objs[4].ValidatorAddress,
+				extraArgs:          common,
+				obj:                objs[4],
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+				args := append([]string{tc.idDepositorAddress, tc.idValidatorAddress}, tc.extraArgs...)
+				out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdShowDeposit(), args)
+				require.NoError(t, err)
+				var resp types.QueryGetDepositResponse
+				require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+				require.NotNil(t, resp.Deposit)
+				require.Equal(t, tc.obj, resp.Deposit)
+			})
+		}
+	})
+
+	// TESTS: SHOW SINGLE - ERRORS
+	t.Run("Show-Errors", func(t *testing.T) {
+		common := []string{fmt.Sprintf("--%s=json", tmcli.OutputFlag)}
+		for _, tc := range []struct {
+			desc               string
+			idDepositorAddress string
+			idValidatorAddress string
+			extraArgs          []string
+			expErrMsg          string
+			expErrCode         codes.Code
+		}{
+			{
+				desc:               "NotFound",
+				idDepositorAddress: objs[0].DepositorAddress,
+				idValidatorAddress: objs[4].ValidatorAddress,
+				extraArgs:          common,
+				expErrMsg:          "key not found",
+				expErrCode:         codes.NotFound,
+			},
+			{
+				desc:               "Bech32Failed-Decoding",
+				idDepositorAddress: sample.MockAddress(),
+				idValidatorAddress: objs[0].ValidatorAddress,
+				extraArgs:          common,
+				expErrMsg:          "invalid request",
+				expErrCode:         codes.InvalidArgument,
+			},
+			{
+				desc:               "Bech32Failed-InvalidDelegator",
+				idDepositorAddress: objs[0].ValidatorAddress,
+				idValidatorAddress: objs[0].ValidatorAddress,
+				extraArgs:          common,
+				expErrMsg:          "invalid request",
+				expErrCode:         codes.InvalidArgument,
+			},
+			{
+				desc:               "Bech32Failed-InvalidValidator",
+				idDepositorAddress: objs[0].DepositorAddress,
+				idValidatorAddress: objs[0].DepositorAddress,
+				extraArgs:          common,
+				expErrMsg:          "invalid request",
+				expErrCode:         codes.InvalidArgument,
+			},
+			{
+				desc:               "Bech32Failed-EmptyDelegator",
+				idDepositorAddress: "",
+				idValidatorAddress: objs[0].ValidatorAddress,
+				extraArgs:          common,
+				expErrMsg:          "invalid request",
+				expErrCode:         codes.InvalidArgument,
+			},
+			{
+				desc:               "Bech32Failed-EmptyValidator",
+				idDepositorAddress: objs[0].DepositorAddress,
+				idValidatorAddress: "",
+				extraArgs:          common,
+				expErrMsg:          "invalid request",
+				expErrCode:         codes.InvalidArgument,
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+				args := append([]string{tc.idDepositorAddress, tc.idValidatorAddress}, tc.extraArgs...)
+
+				// ensure the execution returns an error with expErrMsg in its description
+				out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdShowDeposit(), args)
+				require.Contains(t, err.Error(), tc.expErrMsg)
+
+				// ensure the output cannot be unmarshaled
+				var resp, nullresp types.QueryGetDepositResponse
+				require.Error(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+				require.Equal(t, nullresp.Deposit, resp.Deposit)
+
+				// ensure the error is compatible with package grpc/status, results in status with proper code and with expErrMsg in its description
+				stat, ok := status.FromError(err)
+				require.True(t, ok)
+				require.Equal(t, tc.expErrCode, stat.Code())
+				require.Contains(t, stat.Message(), tc.expErrMsg)
+			})
+		}
 	})
 }

--- a/x/slashrefund/client/cli/query_params_test.go
+++ b/x/slashrefund/client/cli/query_params_test.go
@@ -1,0 +1,48 @@
+package cli_test
+
+import (
+	"fmt"
+	"testing"
+
+	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
+	"github.com/made-in-block/slash-refund/x/slashrefund/client/cli"
+	"github.com/stretchr/testify/require"
+
+	"github.com/made-in-block/slash-refund/testutil/network"
+	"github.com/made-in-block/slash-refund/x/slashrefund/types"
+
+	tmcli "github.com/tendermint/tendermint/libs/cli"
+)
+
+func networkWithParams(t *testing.T, params types.Params) (*network.Network, types.Params) {
+	t.Helper()
+	cfg := network.DefaultConfig()
+	state := types.GenesisState{}
+	require.NoError(t, cfg.Codec.UnmarshalJSON(cfg.GenesisState[types.ModuleName], &state))
+
+	state.Params = params
+	buf, err := cfg.Codec.MarshalJSON(&state)
+	require.NoError(t, err)
+	cfg.GenesisState[types.ModuleName] = buf
+	return network.New(t, cfg), state.Params
+}
+
+func TestQueryParams(t *testing.T) {
+	net, params := networkWithParams(t,
+		types.Params{
+			AllowedTokens: []string{"foo"},
+		})
+	ctx := net.Validators[0].ClientCtx
+
+	t.Run("Query-Valid", func(t *testing.T) {
+
+		args := []string{fmt.Sprintf("--%s=json", tmcli.OutputFlag)}
+		out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdQueryParams(), args)
+		require.NoError(t, err)
+
+		var resp types.QueryParamsResponse
+		require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+		require.NotNil(t, resp.Params)
+		require.Equal(t, params, resp.Params)
+	})
+}

--- a/x/slashrefund/client/cli/query_refund_pool_test.go
+++ b/x/slashrefund/client/cli/query_refund_pool_test.go
@@ -2,24 +2,21 @@ package cli_test
 
 import (
 	"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 	tmcli "github.com/tendermint/tendermint/libs/cli"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/made-in-block/slash-refund/testutil/network"
-	"github.com/made-in-block/slash-refund/testutil/nullify"
+	"github.com/made-in-block/slash-refund/testutil/sample"
 	"github.com/made-in-block/slash-refund/x/slashrefund/client/cli"
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
 )
-
-// Prevent strconv unused error
-var _ = strconv.IntSize
 
 func networkWithRefundPoolObjects(t *testing.T, n int) (*network.Network, []types.RefundPool) {
 	t.Helper()
@@ -29,9 +26,10 @@ func networkWithRefundPoolObjects(t *testing.T, n int) (*network.Network, []type
 
 	for i := 0; i < n; i++ {
 		refundPool := types.RefundPool{
-			OperatorAddress: strconv.Itoa(i),
+			OperatorAddress: sample.ValAddress(),
+			Tokens:          sdk.NewCoin("stake", sdk.NewInt(int64(100*(i+1)))),
+			Shares:          sdk.NewDec(int64(100 * (i + 1))),
 		}
-		nullify.Fill(&refundPool)
 		state.RefundPoolList = append(state.RefundPoolList, refundPool)
 	}
 	buf, err := cfg.Codec.MarshalJSON(&state)
@@ -40,64 +38,10 @@ func networkWithRefundPoolObjects(t *testing.T, n int) (*network.Network, []type
 	return network.New(t, cfg), state.RefundPoolList
 }
 
-func TestShowRefundPool(t *testing.T) {
-	net, objs := networkWithRefundPoolObjects(t, 2)
-
-	ctx := net.Validators[0].ClientCtx
-	common := []string{
-		fmt.Sprintf("--%s=json", tmcli.OutputFlag),
-	}
-	for _, tc := range []struct {
-		desc              string
-		idOperatorAddress string
-
-		args []string
-		err  error
-		obj  types.RefundPool
-	}{
-		{
-			desc:              "found",
-			idOperatorAddress: objs[0].OperatorAddress,
-
-			args: common,
-			obj:  objs[0],
-		},
-		{
-			desc:              "not found",
-			idOperatorAddress: strconv.Itoa(100000),
-
-			args: common,
-			err:  status.Error(codes.NotFound, "not found"),
-		},
-	} {
-		t.Run(tc.desc, func(t *testing.T) {
-			args := []string{
-				tc.idOperatorAddress,
-			}
-			args = append(args, tc.args...)
-			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdShowRefundPool(), args)
-			if tc.err != nil {
-				stat, ok := status.FromError(tc.err)
-				require.True(t, ok)
-				require.ErrorIs(t, stat.Err(), tc.err)
-			} else {
-				require.NoError(t, err)
-				var resp types.QueryGetRefundPoolResponse
-				require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
-				require.NotNil(t, resp.RefundPool)
-				require.Equal(t,
-					nullify.Fill(&tc.obj),
-					nullify.Fill(&resp.RefundPool),
-				)
-			}
-		})
-	}
-}
-
-func TestListRefundPool(t *testing.T) {
+func TestQueryRefundPool(t *testing.T) {
 	net, objs := networkWithRefundPoolObjects(t, 5)
-
 	ctx := net.Validators[0].ClientCtx
+
 	request := func(next []byte, offset, limit uint64, total bool) []string {
 		args := []string{
 			fmt.Sprintf("--%s=json", tmcli.OutputFlag),
@@ -122,10 +66,7 @@ func TestListRefundPool(t *testing.T) {
 			var resp types.QueryAllRefundPoolResponse
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.RefundPool), step)
-			require.Subset(t,
-				nullify.Fill(objs),
-				nullify.Fill(resp.RefundPool),
-			)
+			require.Subset(t, objs, resp.RefundPool)
 		}
 	})
 	t.Run("ByKey", func(t *testing.T) {
@@ -138,10 +79,7 @@ func TestListRefundPool(t *testing.T) {
 			var resp types.QueryAllRefundPoolResponse
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.RefundPool), step)
-			require.Subset(t,
-				nullify.Fill(objs),
-				nullify.Fill(resp.RefundPool),
-			)
+			require.Subset(t, objs, resp.RefundPool)
 			next = resp.Pagination.NextKey
 		}
 	})
@@ -153,9 +91,118 @@ func TestListRefundPool(t *testing.T) {
 		require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 		require.NoError(t, err)
 		require.Equal(t, len(objs), int(resp.Pagination.Total))
-		require.ElementsMatch(t,
-			nullify.Fill(objs),
-			nullify.Fill(resp.RefundPool),
-		)
+		require.ElementsMatch(t, objs, resp.RefundPool)
+	})
+
+	// TESTS: SHOW SINGLE - VALID
+	t.Run("Show-Valid", func(t *testing.T) {
+		common := []string{fmt.Sprintf("--%s=json", tmcli.OutputFlag)}
+		for _, tc := range []struct {
+			desc               string
+			idValidatorAddress string
+			extraArgs          []string
+			obj                types.RefundPool
+		}{
+			{
+				desc:               "Found0",
+				idValidatorAddress: objs[0].OperatorAddress,
+				extraArgs:          common,
+				obj:                objs[0],
+			},
+			{
+				desc:               "Found1",
+				idValidatorAddress: objs[1].OperatorAddress,
+				extraArgs:          common,
+				obj:                objs[1],
+			},
+			{
+				desc:               "Found2",
+				idValidatorAddress: objs[2].OperatorAddress,
+				extraArgs:          common,
+				obj:                objs[2],
+			},
+			{
+				desc:               "Found3",
+				idValidatorAddress: objs[3].OperatorAddress,
+				extraArgs:          common,
+				obj:                objs[3],
+			},
+			{
+				desc:               "Found4",
+				idValidatorAddress: objs[4].OperatorAddress,
+				extraArgs:          common,
+				obj:                objs[4],
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+				args := append([]string{tc.idValidatorAddress}, tc.extraArgs...)
+				out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdShowRefundPool(), args)
+				require.NoError(t, err)
+				var resp types.QueryGetRefundPoolResponse
+				require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+				require.NotNil(t, resp.RefundPool)
+				require.Equal(t, tc.obj, resp.RefundPool)
+			})
+		}
+	})
+
+	// TESTS: SHOW SINGLE - ERRORS
+	t.Run("Show-Errors", func(t *testing.T) {
+		common := []string{fmt.Sprintf("--%s=json", tmcli.OutputFlag)}
+		for _, tc := range []struct {
+			desc               string
+			idValidatorAddress string
+			extraArgs          []string
+			expErrMsg          string
+			expErrCode         codes.Code
+		}{
+			{
+				desc:               "NotFound",
+				idValidatorAddress: sample.ValAddress(),
+				extraArgs:          common,
+				expErrMsg:          "key not found",
+				expErrCode:         codes.NotFound,
+			},
+			{
+				desc:               "Bech32Failed-Decoding",
+				idValidatorAddress: sample.MockAddress(),
+				extraArgs:          common,
+				expErrMsg:          "invalid request",
+				expErrCode:         codes.InvalidArgument,
+			},
+			{
+				desc:               "Bech32Failed-InvalidValidator",
+				idValidatorAddress: sample.AccAddress(),
+				extraArgs:          common,
+				expErrMsg:          "invalid request",
+				expErrCode:         codes.InvalidArgument,
+			},
+			{
+				desc:               "Bech32Failed-EmptyValidator",
+				idValidatorAddress: "",
+				extraArgs:          common,
+				expErrMsg:          "invalid request",
+				expErrCode:         codes.InvalidArgument,
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+				args := append([]string{tc.idValidatorAddress}, tc.extraArgs...)
+
+				// ensure the execution returns an error with expErrMsg in its description
+				out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdShowRefundPool(), args)
+				require.Contains(t, err.Error(), tc.expErrMsg)
+
+				// ensure the output cannot be unmarshaled
+				var resp, nullresp types.QueryGetRefundPoolResponse
+				require.Error(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+				require.Equal(t, nullresp.RefundPool, resp.RefundPool)
+
+				// ensure the error is compatible with package grpc/status, results in status with proper code and with expErrMsg in its description
+				stat, ok := status.FromError(err)
+				require.True(t, ok)
+				require.Equal(t, tc.expErrCode, stat.Code())
+				require.Contains(t, stat.Message(), tc.expErrMsg)
+			})
+		}
 	})
 }

--- a/x/slashrefund/client/cli/query_refund_test.go
+++ b/x/slashrefund/client/cli/query_refund_test.go
@@ -2,24 +2,21 @@ package cli_test
 
 import (
 	"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 	tmcli "github.com/tendermint/tendermint/libs/cli"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/made-in-block/slash-refund/testutil/network"
-	"github.com/made-in-block/slash-refund/testutil/nullify"
+	"github.com/made-in-block/slash-refund/testutil/sample"
 	"github.com/made-in-block/slash-refund/x/slashrefund/client/cli"
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
 )
-
-// Prevent strconv unused error
-var _ = strconv.IntSize
 
 func networkWithRefundObjects(t *testing.T, n int) (*network.Network, []types.Refund) {
 	t.Helper()
@@ -29,10 +26,10 @@ func networkWithRefundObjects(t *testing.T, n int) (*network.Network, []types.Re
 
 	for i := 0; i < n; i++ {
 		refund := types.Refund{
-			DelegatorAddress: strconv.Itoa(i),
-			ValidatorAddress: strconv.Itoa(i),
+			DelegatorAddress: sample.AccAddress(),
+			ValidatorAddress: sample.ValAddress(),
+			Shares:           sdk.NewDec(int64(100 * (i + 1))),
 		}
-		nullify.Fill(&refund)
 		state.RefundList = append(state.RefundList, refund)
 	}
 	buf, err := cfg.Codec.MarshalJSON(&state)
@@ -41,68 +38,10 @@ func networkWithRefundObjects(t *testing.T, n int) (*network.Network, []types.Re
 	return network.New(t, cfg), state.RefundList
 }
 
-func TestShowRefund(t *testing.T) {
-	net, objs := networkWithRefundObjects(t, 2)
-
-	ctx := net.Validators[0].ClientCtx
-	common := []string{
-		fmt.Sprintf("--%s=json", tmcli.OutputFlag),
-	}
-	for _, tc := range []struct {
-		desc        string
-		idDelegator string
-		idValidator string
-
-		args []string
-		err  error
-		obj  types.Refund
-	}{
-		{
-			desc:        "found",
-			idDelegator: objs[0].DelegatorAddress,
-			idValidator: objs[0].ValidatorAddress,
-
-			args: common,
-			obj:  objs[0],
-		},
-		{
-			desc:        "not found",
-			idDelegator: strconv.Itoa(100000),
-			idValidator: strconv.Itoa(100000),
-
-			args: common,
-			err:  status.Error(codes.NotFound, "not found"),
-		},
-	} {
-		t.Run(tc.desc, func(t *testing.T) {
-			args := []string{
-				tc.idDelegator,
-				tc.idValidator,
-			}
-			args = append(args, tc.args...)
-			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdShowRefund(), args)
-			if tc.err != nil {
-				stat, ok := status.FromError(tc.err)
-				require.True(t, ok)
-				require.ErrorIs(t, stat.Err(), tc.err)
-			} else {
-				require.NoError(t, err)
-				var resp types.QueryGetRefundResponse
-				require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
-				require.NotNil(t, resp.Refund)
-				require.Equal(t,
-					nullify.Fill(&tc.obj),
-					nullify.Fill(&resp.Refund),
-				)
-			}
-		})
-	}
-}
-
-func TestListRefund(t *testing.T) {
+func TestQueryRefund(t *testing.T) {
 	net, objs := networkWithRefundObjects(t, 5)
-
 	ctx := net.Validators[0].ClientCtx
+
 	request := func(next []byte, offset, limit uint64, total bool) []string {
 		args := []string{
 			fmt.Sprintf("--%s=json", tmcli.OutputFlag),
@@ -118,6 +57,7 @@ func TestListRefund(t *testing.T) {
 		}
 		return args
 	}
+
 	t.Run("ByOffset", func(t *testing.T) {
 		step := 2
 		for i := 0; i < len(objs); i += step {
@@ -127,12 +67,10 @@ func TestListRefund(t *testing.T) {
 			var resp types.QueryAllRefundResponse
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.Refund), step)
-			require.Subset(t,
-				nullify.Fill(objs),
-				nullify.Fill(resp.Refund),
-			)
+			require.Subset(t, objs, resp.Refund)
 		}
 	})
+
 	t.Run("ByKey", func(t *testing.T) {
 		step := 2
 		var next []byte
@@ -143,13 +81,11 @@ func TestListRefund(t *testing.T) {
 			var resp types.QueryAllRefundResponse
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.Refund), step)
-			require.Subset(t,
-				nullify.Fill(objs),
-				nullify.Fill(resp.Refund),
-			)
+			require.Subset(t, objs, resp.Refund)
 			next = resp.Pagination.NextKey
 		}
 	})
+
 	t.Run("Total", func(t *testing.T) {
 		args := request(nil, 0, uint64(len(objs)), true)
 		out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdListRefund(), args)
@@ -158,9 +94,145 @@ func TestListRefund(t *testing.T) {
 		require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 		require.NoError(t, err)
 		require.Equal(t, len(objs), int(resp.Pagination.Total))
-		require.ElementsMatch(t,
-			nullify.Fill(objs),
-			nullify.Fill(resp.Refund),
-		)
+		require.ElementsMatch(t, objs, resp.Refund)
+	})
+
+	// TESTS: SHOW SINGLE - VALID
+	t.Run("Show-Valid", func(t *testing.T) {
+		common := []string{fmt.Sprintf("--%s=json", tmcli.OutputFlag)}
+		for _, tc := range []struct {
+			desc               string
+			idDelegatorAddress string
+			idValidatorAddress string
+			extraArgs          []string
+			obj                types.Refund
+		}{
+			{
+				desc:               "Found0",
+				idDelegatorAddress: objs[0].DelegatorAddress,
+				idValidatorAddress: objs[0].ValidatorAddress,
+				extraArgs:          common,
+				obj:                objs[0],
+			},
+			{
+				desc:               "Found1",
+				idDelegatorAddress: objs[1].DelegatorAddress,
+				idValidatorAddress: objs[1].ValidatorAddress,
+				extraArgs:          common,
+				obj:                objs[1],
+			},
+			{
+				desc:               "Found2",
+				idDelegatorAddress: objs[2].DelegatorAddress,
+				idValidatorAddress: objs[2].ValidatorAddress,
+				extraArgs:          common,
+				obj:                objs[2],
+			},
+			{
+				desc:               "Found3",
+				idDelegatorAddress: objs[3].DelegatorAddress,
+				idValidatorAddress: objs[3].ValidatorAddress,
+				extraArgs:          common,
+				obj:                objs[3],
+			},
+			{
+				desc:               "Found4",
+				idDelegatorAddress: objs[4].DelegatorAddress,
+				idValidatorAddress: objs[4].ValidatorAddress,
+				extraArgs:          common,
+				obj:                objs[4],
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+				args := append([]string{tc.idDelegatorAddress, tc.idValidatorAddress}, tc.extraArgs...)
+				out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdShowRefund(), args)
+				require.NoError(t, err)
+				var resp types.QueryGetRefundResponse
+				require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+				require.NotNil(t, resp.Refund)
+				require.Equal(t, tc.obj, resp.Refund)
+			})
+		}
+	})
+
+	// TESTS: SHOW SINGLE - ERRORS
+	t.Run("Show-Errors", func(t *testing.T) {
+		common := []string{fmt.Sprintf("--%s=json", tmcli.OutputFlag)}
+		for _, tc := range []struct {
+			desc               string
+			idDelegatorAddress string
+			idValidatorAddress string
+			extraArgs          []string
+			expErrMsg          string
+			expErrCode         codes.Code
+		}{
+			{
+				desc:               "NotFound",
+				idDelegatorAddress: objs[0].DelegatorAddress,
+				idValidatorAddress: objs[4].ValidatorAddress,
+				extraArgs:          common,
+				expErrMsg:          "key not found",
+				expErrCode:         codes.NotFound,
+			},
+			{
+				desc:               "Bech32Failed-Decoding",
+				idDelegatorAddress: sample.MockAddress(),
+				idValidatorAddress: objs[0].ValidatorAddress,
+				extraArgs:          common,
+				expErrMsg:          "invalid request",
+				expErrCode:         codes.InvalidArgument,
+			},
+			{
+				desc:               "Bech32Failed-InvalidDelegator",
+				idDelegatorAddress: objs[0].ValidatorAddress,
+				idValidatorAddress: objs[0].ValidatorAddress,
+				extraArgs:          common,
+				expErrMsg:          "invalid request",
+				expErrCode:         codes.InvalidArgument,
+			},
+			{
+				desc:               "Bech32Failed-InvalidValidator",
+				idDelegatorAddress: objs[0].DelegatorAddress,
+				idValidatorAddress: objs[0].DelegatorAddress,
+				extraArgs:          common,
+				expErrMsg:          "invalid request",
+				expErrCode:         codes.InvalidArgument,
+			},
+			{
+				desc:               "Bech32Failed-EmptyDelegator",
+				idDelegatorAddress: "",
+				idValidatorAddress: objs[0].ValidatorAddress,
+				extraArgs:          common,
+				expErrMsg:          "invalid request",
+				expErrCode:         codes.InvalidArgument,
+			},
+			{
+				desc:               "Bech32Failed-EmptyValidator",
+				idDelegatorAddress: objs[0].DelegatorAddress,
+				idValidatorAddress: "",
+				extraArgs:          common,
+				expErrMsg:          "invalid request",
+				expErrCode:         codes.InvalidArgument,
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+				args := append([]string{tc.idDelegatorAddress, tc.idValidatorAddress}, tc.extraArgs...)
+
+				// ensure the execution returns an error with expErrMsg in its description
+				out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdShowRefund(), args)
+				require.Contains(t, err.Error(), tc.expErrMsg)
+
+				// ensure the output cannot be unmarshaled
+				var resp, nullresp types.QueryGetRefundResponse
+				require.Error(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+				require.Equal(t, nullresp.Refund, resp.Refund)
+
+				// ensure the error is compatible with package grpc/status, results in status with proper code and with expErrMsg in its description
+				stat, ok := status.FromError(err)
+				require.True(t, ok)
+				require.Equal(t, tc.expErrCode, stat.Code())
+				require.Contains(t, stat.Message(), tc.expErrMsg)
+			})
+		}
 	})
 }

--- a/x/slashrefund/client/cli/query_unbonding_deposit_test.go
+++ b/x/slashrefund/client/cli/query_unbonding_deposit_test.go
@@ -2,24 +2,22 @@ package cli_test
 
 import (
 	"fmt"
-	"strconv"
 	"testing"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 	tmcli "github.com/tendermint/tendermint/libs/cli"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/made-in-block/slash-refund/testutil/network"
-	"github.com/made-in-block/slash-refund/testutil/nullify"
+	"github.com/made-in-block/slash-refund/testutil/sample"
 	"github.com/made-in-block/slash-refund/x/slashrefund/client/cli"
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
 )
-
-// Prevent strconv unused error
-var _ = strconv.IntSize
 
 func networkWithUnbondingDepositObjects(t *testing.T, n int) (*network.Network, []types.UnbondingDeposit) {
 	t.Helper()
@@ -29,10 +27,23 @@ func networkWithUnbondingDepositObjects(t *testing.T, n int) (*network.Network, 
 
 	for i := 0; i < n; i++ {
 		unbondingDeposit := types.UnbondingDeposit{
-			DepositorAddress: strconv.Itoa(i),
-			ValidatorAddress: strconv.Itoa(i),
+			DepositorAddress: sample.AccAddress(),
+			ValidatorAddress: sample.ValAddress(),
+			Entries: []types.UnbondingDepositEntry{
+				{
+					CreationHeight: int64(i),
+					CompletionTime: time.Date(1970, time.January, 1, i, i, i, i, time.UTC),
+					InitialBalance: sdk.NewInt(int64(100 * (i + 1))),
+					Balance:        sdk.NewInt(int64(100 * i)),
+				},
+				{
+					CreationHeight: int64(i + 1),
+					CompletionTime: time.Date(1970, time.January, 1, i+1, i+1, i+1, i+1, time.UTC),
+					InitialBalance: sdk.NewInt(int64(100 * (i + 2))),
+					Balance:        sdk.NewInt(int64(100 * (i + 1))),
+				},
+			},
 		}
-		nullify.Fill(&unbondingDeposit)
 		state.UnbondingDepositList = append(state.UnbondingDepositList, unbondingDeposit)
 	}
 	buf, err := cfg.Codec.MarshalJSON(&state)
@@ -41,68 +52,11 @@ func networkWithUnbondingDepositObjects(t *testing.T, n int) (*network.Network, 
 	return network.New(t, cfg), state.UnbondingDepositList
 }
 
-func TestShowUnbondingDeposit(t *testing.T) {
-	net, objs := networkWithUnbondingDepositObjects(t, 2)
-
-	ctx := net.Validators[0].ClientCtx
-	common := []string{
-		fmt.Sprintf("--%s=json", tmcli.OutputFlag),
-	}
-	for _, tc := range []struct {
-		desc               string
-		idDepositorAddress string
-		idValidatorAddress string
-
-		args []string
-		err  error
-		obj  types.UnbondingDeposit
-	}{
-		{
-			desc:               "found",
-			idDepositorAddress: objs[0].DepositorAddress,
-			idValidatorAddress: objs[0].ValidatorAddress,
-
-			args: common,
-			obj:  objs[0],
-		},
-		{
-			desc:               "not found",
-			idDepositorAddress: strconv.Itoa(100000),
-			idValidatorAddress: strconv.Itoa(100000),
-
-			args: common,
-			err:  status.Error(codes.NotFound, "not found"),
-		},
-	} {
-		t.Run(tc.desc, func(t *testing.T) {
-			args := []string{
-				tc.idDepositorAddress,
-				tc.idValidatorAddress,
-			}
-			args = append(args, tc.args...)
-			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdShowUnbondingDeposit(), args)
-			if tc.err != nil {
-				stat, ok := status.FromError(tc.err)
-				require.True(t, ok)
-				require.ErrorIs(t, stat.Err(), tc.err)
-			} else {
-				require.NoError(t, err)
-				var resp types.QueryGetUnbondingDepositResponse
-				require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
-				require.NotNil(t, resp.UnbondingDeposit)
-				require.Equal(t,
-					nullify.Fill(&tc.obj),
-					nullify.Fill(&resp.UnbondingDeposit),
-				)
-			}
-		})
-	}
-}
-
-func TestListUnbondingDeposit(t *testing.T) {
+func TestQueryUnbondingDeposit(t *testing.T) {
 	net, objs := networkWithUnbondingDepositObjects(t, 5)
-
 	ctx := net.Validators[0].ClientCtx
+
+	// TESTS: LIST ALL
 	request := func(next []byte, offset, limit uint64, total bool) []string {
 		args := []string{
 			fmt.Sprintf("--%s=json", tmcli.OutputFlag),
@@ -118,7 +72,7 @@ func TestListUnbondingDeposit(t *testing.T) {
 		}
 		return args
 	}
-	t.Run("ByOffset", func(t *testing.T) {
+	t.Run("List-ByOffset", func(t *testing.T) {
 		step := 2
 		for i := 0; i < len(objs); i += step {
 			args := request(nil, uint64(i), uint64(step), false)
@@ -127,13 +81,10 @@ func TestListUnbondingDeposit(t *testing.T) {
 			var resp types.QueryAllUnbondingDepositResponse
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.UnbondingDeposit), step)
-			require.Subset(t,
-				nullify.Fill(objs),
-				nullify.Fill(resp.UnbondingDeposit),
-			)
+			require.Subset(t, objs, resp.UnbondingDeposit)
 		}
 	})
-	t.Run("ByKey", func(t *testing.T) {
+	t.Run("List-ByKey", func(t *testing.T) {
 		step := 2
 		var next []byte
 		for i := 0; i < len(objs); i += step {
@@ -143,14 +94,11 @@ func TestListUnbondingDeposit(t *testing.T) {
 			var resp types.QueryAllUnbondingDepositResponse
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.UnbondingDeposit), step)
-			require.Subset(t,
-				nullify.Fill(objs),
-				nullify.Fill(resp.UnbondingDeposit),
-			)
+			require.Subset(t, objs, resp.UnbondingDeposit)
 			next = resp.Pagination.NextKey
 		}
 	})
-	t.Run("Total", func(t *testing.T) {
+	t.Run("List-Total", func(t *testing.T) {
 		args := request(nil, 0, uint64(len(objs)), true)
 		out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdListUnbondingDeposit(), args)
 		require.NoError(t, err)
@@ -158,9 +106,145 @@ func TestListUnbondingDeposit(t *testing.T) {
 		require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 		require.NoError(t, err)
 		require.Equal(t, len(objs), int(resp.Pagination.Total))
-		require.ElementsMatch(t,
-			nullify.Fill(objs),
-			nullify.Fill(resp.UnbondingDeposit),
-		)
+		require.ElementsMatch(t, objs, resp.UnbondingDeposit)
+	})
+
+	// TESTS: SHOW SINGLE - VALID
+	t.Run("Show-Valid", func(t *testing.T) {
+		common := []string{fmt.Sprintf("--%s=json", tmcli.OutputFlag)}
+		for _, tc := range []struct {
+			desc               string
+			idDepositorAddress string
+			idValidatorAddress string
+			extraArgs          []string
+			obj                types.UnbondingDeposit
+		}{
+			{
+				desc:               "Single-Found0",
+				idDepositorAddress: objs[0].DepositorAddress,
+				idValidatorAddress: objs[0].ValidatorAddress,
+				extraArgs:          common,
+				obj:                objs[0],
+			},
+			{
+				desc:               "Single-Found1",
+				idDepositorAddress: objs[1].DepositorAddress,
+				idValidatorAddress: objs[1].ValidatorAddress,
+				extraArgs:          common,
+				obj:                objs[1],
+			},
+			{
+				desc:               "Single-Found2",
+				idDepositorAddress: objs[2].DepositorAddress,
+				idValidatorAddress: objs[2].ValidatorAddress,
+				extraArgs:          common,
+				obj:                objs[2],
+			},
+			{
+				desc:               "Single-Found3",
+				idDepositorAddress: objs[3].DepositorAddress,
+				idValidatorAddress: objs[3].ValidatorAddress,
+				extraArgs:          common,
+				obj:                objs[3],
+			},
+			{
+				desc:               "Single-Found4",
+				idDepositorAddress: objs[4].DepositorAddress,
+				idValidatorAddress: objs[4].ValidatorAddress,
+				extraArgs:          common,
+				obj:                objs[4],
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+				args := append([]string{tc.idDepositorAddress, tc.idValidatorAddress}, tc.extraArgs...)
+				out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdShowUnbondingDeposit(), args)
+				require.NoError(t, err)
+				var resp types.QueryGetUnbondingDepositResponse
+				require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+				require.NotNil(t, resp.UnbondingDeposit)
+				require.Equal(t, tc.obj, resp.UnbondingDeposit)
+			})
+		}
+	})
+
+	// TESTS: SHOW SINGLE - ERRORS
+	t.Run("Show-Errors", func(t *testing.T) {
+		common := []string{fmt.Sprintf("--%s=json", tmcli.OutputFlag)}
+		for _, tc := range []struct {
+			desc               string
+			idDepositorAddress string
+			idValidatorAddress string
+			extraArgs          []string
+			expErrMsg          string
+			expErrCode         codes.Code
+		}{
+			{
+				desc:               "NotFound",
+				idDepositorAddress: objs[0].DepositorAddress,
+				idValidatorAddress: objs[4].ValidatorAddress,
+				extraArgs:          common,
+				expErrMsg:          "key not found",
+				expErrCode:         codes.NotFound,
+			},
+			{
+				desc:               "Bech32Failed",
+				idDepositorAddress: sample.MockAddress(),
+				idValidatorAddress: objs[0].ValidatorAddress,
+				extraArgs:          common,
+				expErrMsg:          "invalid request",
+				expErrCode:         codes.InvalidArgument,
+			},
+			{
+				desc:               "Bech32Failed-InvalidDepositor",
+				idDepositorAddress: objs[0].ValidatorAddress,
+				idValidatorAddress: objs[0].ValidatorAddress,
+				extraArgs:          common,
+				expErrMsg:          "invalid request",
+				expErrCode:         codes.InvalidArgument,
+			},
+			{
+				desc:               "Bech32Failed-InvalidValidator",
+				idDepositorAddress: objs[0].DepositorAddress,
+				idValidatorAddress: objs[0].DepositorAddress,
+				extraArgs:          common,
+				expErrMsg:          "invalid request",
+				expErrCode:         codes.InvalidArgument,
+			},
+			{
+				desc:               "Bech32Failed-EmptyDepositor",
+				idDepositorAddress: "",
+				idValidatorAddress: objs[0].ValidatorAddress,
+				extraArgs:          common,
+				expErrMsg:          "invalid request",
+				expErrCode:         codes.InvalidArgument,
+			},
+			{
+				desc:               "Bech32Failed-EmptyValidator",
+				idDepositorAddress: objs[0].DepositorAddress,
+				idValidatorAddress: "",
+				extraArgs:          common,
+				expErrMsg:          "invalid request",
+				expErrCode:         codes.InvalidArgument,
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+				args := append([]string{tc.idDepositorAddress, tc.idValidatorAddress}, tc.extraArgs...)
+
+				// ensure the execution returns an error with expErrMsg in its description
+				out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdShowUnbondingDeposit(), args)
+				require.Contains(t, err.Error(), tc.expErrMsg)
+
+				// ensure the output cannot be unmarshaled
+				var resp, nullresp types.QueryGetUnbondingDepositResponse
+				require.Error(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+				require.Equal(t, nullresp.UnbondingDeposit, resp.UnbondingDeposit)
+
+				// ensure the error is compatible with package grpc/status, results in status with proper code and with expErrMsg in its description
+				stat, ok := status.FromError(err)
+				require.True(t, ok)
+				require.Equal(t, tc.expErrCode, stat.Code())
+				require.Contains(t, stat.Message(), tc.expErrMsg)
+			})
+		}
 	})
 }

--- a/x/slashrefund/client/cli/tx_claim.go
+++ b/x/slashrefund/client/cli/tx_claim.go
@@ -1,16 +1,12 @@
 package cli
 
 import (
-	"strconv"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
 	"github.com/spf13/cobra"
 )
-
-var _ = strconv.Itoa(0)
 
 func CmdClaim() *cobra.Command {
 	cmd := &cobra.Command{

--- a/x/slashrefund/client/cli/tx_deposit.go
+++ b/x/slashrefund/client/cli/tx_deposit.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"strconv"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -10,8 +8,6 @@ import (
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
 	"github.com/spf13/cobra"
 )
-
-var _ = strconv.Itoa(0)
 
 func CmdDeposit() *cobra.Command {
 

--- a/x/slashrefund/client/cli/tx_withdraw.go
+++ b/x/slashrefund/client/cli/tx_withdraw.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"strconv"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -10,8 +8,6 @@ import (
 	"github.com/made-in-block/slash-refund/x/slashrefund/types"
 	"github.com/spf13/cobra"
 )
-
-var _ = strconv.Itoa(0)
 
 func CmdWithdraw() *cobra.Command {
 	cmd := &cobra.Command{

--- a/x/slashrefund/keeper/grpc_query_deposit_pool.go
+++ b/x/slashrefund/keeper/grpc_query_deposit_pool.go
@@ -45,7 +45,7 @@ func (k Querier) DepositPool(c context.Context, req *types.QueryGetDepositPoolRe
 	}
 	valOperAddr, err := sdk.ValAddressFromBech32(req.OperatorAddress)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	ctx := sdk.UnwrapSDKContext(c)
 


### PR DESCRIPTION
This PR:
  - updates the e2e query tests (still under client/cli section before refactor);
  - fixes the deposit pool query that would panic if bech32 decoding failed.