### PR TITLE
fix: update return logic of HasMaxUnbondingEntries (2)

### DIFF
--- a/x/slashrefund/keeper/withdraw.go
+++ b/x/slashrefund/keeper/withdraw.go
@@ -128,5 +128,5 @@ func (k Keeper) HasMaxUnbondingDepositEntries(ctx sdk.Context, depAddr sdk.AccAd
 		return false
 	}
 
-	return len(ubd.Entries) > int(k.MaxEntries(ctx))
+	return len(ubd.Entries) >= int(k.MaxEntries(ctx))
 }


### PR DESCRIPTION
This PR updates the return logic of keeper's function `HasMaxUnbondingEntries` in order to block the first transaction that would cause the unbonding deposit to be set with an extra entry, exceeding the prescribed maximum entries amount.