### PR TITLE
Emit refund event when refund from slash is completed

### DIFF
--- a/x/slashrefund/abci.go
+++ b/x/slashrefund/abci.go
@@ -11,18 +11,17 @@ import (
 
 func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) {
 
-	// Handle slashing event
+	// Get events and iterate through them in order to get the slashing event.
 	events := ctx.EventManager().Events()
 
-	// Iterate all events in this block
 	for _, event := range events {
-		// Check if we have a slashing event and that the event is not coming from a jail action
+
+		// Check if we have a slashing event. Skip the jail event, that also is emitted
+		// by the slashing module as a slashing event, but with different attributes
+		// (first attribute of the jail event is "jailed").
+		// TODO: handle jail slash event better.
 		if event.Type == slashingtypes.EventTypeSlash && string(event.Attributes[0].GetKey()) != "jailed" {
-			// TODO: handle jail slash event better.
-			_, err := k.HandleRefundsFromSlash(ctx, event)
-			if err != nil {
-				// TODO: handle the error
-			}
+			k.HandleRefundsFromSlash(ctx, event)
 		}
 	}
 }

--- a/x/slashrefund/keeper/msg_server.go
+++ b/x/slashrefund/keeper/msg_server.go
@@ -22,10 +22,10 @@ func NewMsgServerImpl(k Keeper) types.MsgServer {
 
 var _ types.MsgServer = msgServer{}
 
-// Deposit manages the deposit of funds from a user to a particular validator into the module's 
+// Deposit manages the deposit of funds from a user to a particular validator into the module's
 // KVStore.
 func (ms msgServer) Deposit(
-	goCtx context.Context, 
+	goCtx context.Context,
 	msg *types.MsgDeposit,
 ) (*types.MsgDepositResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
@@ -84,7 +84,7 @@ func (ms msgServer) Deposit(
 // to a validator. The tokens associated to a validator and the shares ratio can change due to
 // slashing events.
 func (ms msgServer) Withdraw(
-	goCtx context.Context, 
+	goCtx context.Context,
 	msg *types.MsgWithdraw,
 ) (*types.MsgWithdrawResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
@@ -144,7 +144,7 @@ func (ms msgServer) Withdraw(
 }
 
 func (ms msgServer) Claim(
-	goCtx context.Context, 
+	goCtx context.Context,
 	msg *types.MsgClaim,
 ) (*types.MsgClaimResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
@@ -163,13 +163,13 @@ func (ms msgServer) Claim(
 	}
 
 	// Check if delegator address is valid.
-	delegatorAddress, err := sdk.AccAddressFromBech32(msg.DelegatorAddress)
+	delAddr, err := sdk.AccAddressFromBech32(msg.DelegatorAddress)
 	if err != nil {
 		return nil, err
 	}
 
 	// === STATE TRANSITION ===
-	coins, err := ms.k.Claim(ctx, delegatorAddress, valAddr)
+	coins, err := ms.k.Claim(ctx, delAddr, valAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func (ms msgServer) Claim(
 	for _, coin := range coins {
 		ctx.EventManager().EmitEvents(sdk.Events{
 			sdk.NewEvent(
-				types.EventTypeWithdraw,
+				types.EventTypeClaim,
 				sdk.NewAttribute(types.AttributeKeyDelegator, msg.DelegatorAddress),
 				sdk.NewAttribute(types.AttributeKeyValidator, msg.ValidatorAddress),
 				sdk.NewAttribute(types.AttributeKeyToken, coin.Denom),

--- a/x/slashrefund/keeper/refund_test.go
+++ b/x/slashrefund/keeper/refund_test.go
@@ -815,10 +815,13 @@ func TestHandleRefundsFromSlash_DoubleSign(t *testing.T) {
 	burnedRedel := slashFactor.MulInt(redelAmt).TruncateInt()
 	burnedTokens := valBurnedTokens.Add(burnedUbdel).Add(burnedRedel)
 
-	// call slash refund
+	// call slashrefund HandleRefundsFromSlash to trigger the refund process
 	ctx = ctx.WithBlockHeader(tmproto.Header{Height: infractionHeight + 2, Time: slashTime})
-	refAmt, err := srApp.SlashrefundKeeper.HandleRefundsFromSlash(ctx, slashEventDS)
-	require.NoError(t, err)
+	srApp.SlashrefundKeeper.HandleRefundsFromSlash(ctx, slashEventDS)
+
+	// process events to get the refund event
+	valAddrEvent, refAmt := processEvents(t, ctx)
+	require.Equal(t, valAddr, valAddrEvent)
 	require.Equal(t, burnedTokens, refAmt)
 
 	// check refunds
@@ -933,10 +936,13 @@ func TestHandleRefundsFromSlash_DownTime(t *testing.T) {
 	burnedRedel := slashFactor.MulInt(redelAmt).TruncateInt()
 	burnedTokens := valBurnedTokens.Add(burnedUbdel).Add(burnedRedel)
 
-	// call slash refund
+	// call slashrefund HandleRefundsFromSlash to trigger the refund process
 	ctx = ctx.WithBlockHeader(tmproto.Header{Height: infractionHeight + 2, Time: slashTime})
-	refAmt, err := srApp.SlashrefundKeeper.HandleRefundsFromSlash(ctx, slashEventDT)
-	require.NoError(t, err)
+	srApp.SlashrefundKeeper.HandleRefundsFromSlash(ctx, slashEventDT)
+
+	// process events to get the refund event
+	valAddrEvent, refAmt := processEvents(t, ctx)
+	require.Equal(t, valAddr, valAddrEvent)
 	require.Equal(t, burnedTokens, refAmt)
 
 	// check refunds

--- a/x/slashrefund/types/events.go
+++ b/x/slashrefund/types/events.go
@@ -5,6 +5,7 @@ const (
 	EventTypeWithdraw       = "withdraw"
 	EventTypeClaim          = "claim"
 	EventTypeCompleteUnbond = "complete_unbond"
+	EventTypeRefund         = "refund"
 
 	AttributeKeyValidator      = "validator"
 	AttributeKeyDepositor      = "depositor"


### PR DESCRIPTION
This PR:
 - updates keeper function `HandleRefundsFromSlash()` removing its outputs since these are not needed in slashrefund module's abci,
 - adds the refund event, that will be emitted when the refund from slash is compleated without errors,
 - updates keeper function `HandleRefundsFromSlash()` adding the refund event emission,
 - updates keeper tests for  `HandleRefundsFromSlash()` in order to account for this changings,
 - fixes the event emitted when a refund is claimed.